### PR TITLE
Condense repo link and project names

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,34 @@ This is where we collect all of the best stuff from the ecosystem and community.
 
 
 ## APPS
-| App Name | Repo | Website | Description |
-| - | - | - | - |
-| | | |
+| App Name (Repo Link) | Website | Description |
+| - | - | - |
+| | |
 
 ## PLUGINS
-| Plugin Name | Repo | Description |
-|-|-|-|
-| tauri-plugin-positioner | https://github.com/JonasKruckenberg/tauri-plugin-positioner | Helps positioning Tauri windows at known locations |
+| Plugin Name (Repo Link) | Description |
+|-|-|
+| [tauri-plugin-positioner][tauri-plugin-positioner-repo] | Helps positioning Tauri windows at known locations |
 | | |
 
 ## TEMPLATES
-| Template Name | Repo | Description |
-| - | - | - |
-| | |
+| Template Name (Repo Link) | Description |
+| - | - |
+| |
 
 ## TUTORIALS
-| Tutorial Name | Link | Description |
-| - | - | - |
+| Tutorial Name (Link) | Description |
+| - | - |
 | | |
 
 ## BLOG ARTICLES
-| Article Name | Link | Description |
-| - | - | - |
+| Article Name (Link) | Description |
+| - | - |
 | | |
 
 # License
-All content in this repo is licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+All content in this repo is licensed under [CC-BY 4.0][License]
+
+<!-- Links -->
+[tauri-plugin-positioner-repo]: //github.com/JonasKruckenberg/tauri-plugin-positioner
+[License]: https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
Just a suggestion, that if you move all the links to the bottom and condense the repo links and the app names, I think both the source and output will be more readable after hundreds (thousands?) of things get added to this page.