### PR TITLE
Simplify Contributing and PR templates

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -38,7 +38,7 @@ Make sure your pull request follows the guidelines/checklists in this document. 
 
 <!-- Ignore unless you're contributing to Apps -->
 
-- [ ] The app is original and not too simple.
-- [ ] The README is in English.
-- [ ] The app makes a reasonable effort to be fast, lightweight and secure.
-- [ ] If the app closed source, evidence of it being built with Tauri is included.
+- The app is original and not too simple.
+- The README is in English.
+- The app makes a reasonable effort to be fast, lightweight and secure.
+- If the app is closed source, evidence of it being built with Tauri is included.

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -18,11 +18,11 @@ Make sure your pull request follows the guidelines/checklists in this document. 
 
 <!-- Ignore unless you're contributing to Plugins/Integrations -->
 
-- [ ] Works with **Tauri 1.x and onward**.
-- [ ] The project is open source and accepts contributions.
-- [ ] The repo is at least 30 days old.
-- [ ] Documentation is in English.
-- [ ] The project is active and maintained.
+- Works with **Tauri 1.x and onward**.
+- The project is open source and accepts contributions.
+- The repo is at least 30 days old.
+- Documentation is in English.
+- The project is active and maintained.
 
 ## Templates
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -28,11 +28,11 @@ Make sure your pull request follows the guidelines/checklists in this document. 
 
 <!-- Ignore unless you're contributing to Templates -->
 
-- [ ] Works with **Tauri 1.x and onward**.
-- [ ] The repo is at least 30 days old.
-- [ ] Documentation is in English.
-- [ ] The template provides enough information about how to get started and what's included.
-- [ ] The template is pretty different from the existing templates.
+- Works with **Tauri 1.x and onward**.
+- The repo is at least 30 days old.
+- Documentation is in English.
+- The template provides enough information about how to get started and what's included.
+- The template is pretty different from the existing templates.
 
 ## Apps
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,32 +1,44 @@
 # Contribution Guidelines
 
----
+Make sure your pull request follows the guidelines/checklists in this document. Please note that entries can be removed if they do not follow the guidelines. Thank you for your suggestion!
 
-Ensure your pull request adheres to the following guidelines:
+- [ ] Use the following format: `[Title](link) - Description.`
+- [ ] Add entries to the bottom of the correct category.
+- [ ] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
+- [ ] Description does not start with `A` or `An`.
+- [ ] Description is under 24 words.
+- [ ] Description has no links or parenthesis.
+- [ ] Use `backticks` when mentioning package names.
+- [ ] Double-check spelling and grammar.
+- [ ] No trailing whitespace is added to the end of any file.
+- [ ] One suggestion per pull request.
+- [ ] I understand that entries can be removed if they do not follow the guidelines.
 
-- Make sure you put things in the right category!
-- Always add your items to the end of a list. To be fair, the order is first-come-first-serve.
-- Do not use words that are clearly implied in the description, such as  `for Tauri`, `a Tauri plugin`.
-- The description should be short (one sentence in 24 words, no expanded explanation) and meaningful without using emoji.
-- Do not use words that are not relevant to the description such as `Super-Fast` or `Super-Super-Fast`.
-- Don't start the description with `A` or `An`.
-- Make an individual pull request for each suggestion.
-- Use the following format: `[title](link) - Description.`
-- Check your spelling and grammar.
-- Make sure your text editor is set to remove trailing whitespace.
-- New categories or improvements to the existing categorization are welcome, but should be done in a separate pull request.
+## Plugins/Integrations
 
-Thank you for your suggestion!
+<!-- Ignore unless you're contributing to Plugins/Integrations -->
+
+- [ ] Works with **Tauri 1.x and onward**.
+- [ ] The project is open source and accepts contributions.
+- [ ] The repo is at least 30 days old.
+- [ ] Documentation is in English.
+- [ ] The project is active and maintained.
+
+## Templates
+
+<!-- Ignore unless you're contributing to Templates -->
+
+- [ ] Works with **Tauri 1.x and onward**.
+- [ ] The repo is at least 30 days old.
+- [ ] Documentation is in English.
+- [ ] The template provides enough information about how to get started and what's included.
+- [ ] The template is pretty different from the existing templates.
 
 ## Apps
 
-The Apps section gives the opportunity to showcase the awesome things that can be built with Tauri. When submitting your app, make sure to adhere to the following:
+<!-- Ignore unless you're contributing to Apps -->
 
-- The app is using Tauri.
-- The app is original and not too simple.
-- Tauri strives to enable fast, lightweight and secure apps. Therefore we expect featured apps to make a (reasonable) effort to be fast, lightweight and secure.
-- If you're submitting a closed source app, include evidence of it being built with Tauri.
-
-## Violations
-
-Please notice that entries that violate any of the above guidelines can be removed. We tend to be lenient and give you the benefit of the doubt, but spam, malware, projects not using tauri or repeat offenders will get removed.
+- [ ] The app is original and not too simple.
+- [ ] The README is in English.
+- [ ] The app makes a reasonable effort to be fast, lightweight and secure.
+- [ ] If the app closed source, evidence of it being built with Tauri is included.

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -2,17 +2,17 @@
 
 Make sure your pull request follows the guidelines/checklists in this document. Please note that entries can be removed if they do not follow the guidelines. Thank you for your suggestion!
 
-- [ ] Use the following format: `[Title](link) - Description.`
-- [ ] Add entries to the bottom of the correct category.
-- [ ] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
-- [ ] Description does not start with `A` or `An`.
-- [ ] Description is under 24 words.
-- [ ] Description has no links or parenthesis.
-- [ ] Use `backticks` when mentioning package names.
-- [ ] Double-check spelling and grammar.
-- [ ] No trailing whitespace is added to the end of any file.
-- [ ] One suggestion per pull request.
-- [ ] I understand that entries can be removed if they do not follow the guidelines.
+- Use the following format: `[Title](link) - Description.`
+- Add entries to the bottom of the correct category.
+- No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
+- Description does not start with `A` or `An`.
+- Description is under 24 words.
+- Description has no links or parenthesis.
+- Use `backticks` when mentioning package names.
+- Double-check spelling and grammar.
+- No trailing whitespace is added to the end of any file.
+- One suggestion per pull request.
+- I understand that entries can be removed if they do not follow the guidelines.
 
 ## Plugins/Integrations
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,43 +1,42 @@
-- [ ] **I have read the [contributing guidelines](contributing.md).**
+- [ ] Use the following format: `[Title](link) - Description.`
+- [ ] Add entries to the bottom of the correct category.
+- [ ] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
+- [ ] Description does not start with `A` or `An`.
+- [ ] Description is under 24 words.
+- [ ] Description has no links or parenthesis.
+- [ ] Use `backticks` when mentioning package names.
+- [ ] Double-check spelling and grammar.
+- [ ] No trailing whitespace is added to the end of any file.
+- [ ] One suggestion per pull request.
+- [ ] I understand that entries can be removed if they do not follow the guidelines.
 
-- [ ] Title as described.
-- [ ] Added to the right category.
-- [ ] Added to the end of a list.
-- [ ] The description of your item is a sentence with less than 24 words.
-- [ ] No links and parentheses in description. 
-- [ ] The description starts with a capital and ends with a full stop/period.
-- [ ] The description doesn't start with `A` or `An`.
-- [ ] No unnecessary words already provided in the context (e.g. `for Tauri`, `a Tauri plugin`).
-- [ ] Uses proper case for terms (e.g. `GitHub`, `TypeScript`, `ESLint`, etc.)
-- [ ] When mentioning tools, omits versions whenever possible (e.g. use `TypeScript` instead of `TypeScript 4.x`.
-- [ ] When mentioning package names, uses quotes whenever possible.
+### Plugins/Integrations
 
-### Plugins/Tools
+<!-- Ignore unless you're contributing to Plugins/Integrations -->
 
-<!-- Ignore if you are not contributing to Plugins/Tools -->
+- [ ] Works with **Tauri 1.x and onward**.
+- [ ] The project is open source and accepts contributions.
+- [ ] The repo is at least 30 days old.
+- [ ] Documentation is in English.
+- [ ] The project is active and maintained.
 
-- [ ] The plugin/tool is working with **Tauri 1.x and onward**.
-- [ ] The project is Open Source.
-- [ ] The repo should be at least 30 days old.
-- [ ] The documentation is in English.
-- [ ] The project is active and maintained (inactive projects for longer 6 months will be removed without further notice).
-- [ ] The project accepts contributions.
-- [ ] Not a commercial product.
+### Templates
 
-### Starter Templates
+<!-- Ignore unless you're contributing to Templates -->
 
-<!-- Ignore if you are not contributing to Starter Templates -->
-
-- [ ] The starter template is working with **Tauri 1.x and onward**.
-- [ ] The documentation is in English.
-- [ ] The starter template most provide enough instructions / documentation about how to start up and what's is included.
-- [ ] The repo should be at least 30 days old.
-- [ ] Should be differentiable from the existing starter templates.
+- [ ] Works with **Tauri 1.x and onward**.
+- [ ] The repo is at least 30 days old.
+- [ ] Documentation is in English.
+- [ ] The template provides enough information about how to get started and what's included.
+- [ ] The template is pretty different from the existing templates.
 
 ### Apps
 
-<!-- Ignore if you are not contributing to Apps/Websites -->
+<!-- Ignore unless you're contributing to Apps -->
 
-- [ ] The project is Open Source.
-- [ ] The readme is in English.
 - [ ] The app is original and not too simple.
+- [ ] The README is in English.
+- [ ] The app makes a reasonable effort to be fast, lightweight and secure.
+- [ ] If the app closed source, evidence of it being built with Tauri is included.
+
+### Additional Context

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <!--lint disable awesome-heading awesome-github awesome-toc double-link -->
 
-<h2 align='center'>Awesome Tauri</h2>
+<h1 align='center'>Awesome Tauri</h1>
 
 <p align='center'>
-This is where we collect all of the best stuff from the ecosystem and community.
+A curated collection of the best stuff from the Tauri ecosystem and community.
 <br><br>
 
 <a href='https://awesome.re'>
@@ -11,11 +11,14 @@ This is where we collect all of the best stuff from the ecosystem and community.
 </a>
 </p>
 
-## Table of Contents
+### Contents
 - [Get Started](#get-started)
+  - [Templates](#templates)
 - [Plugins](#plugins)
 - [Integrations](#integrations)
 - [Apps](#apps)
+  - [Open Source](#open-source)
+  - [Closed Source](#closed-source)
 - [Tutorials](#tutorials)
 - [Articles](#articles)
 
@@ -37,7 +40,7 @@ This is where we collect all of the best stuff from the ecosystem and community.
 - [tauri-plugin-vibrancy](https://github.com/tauri-apps/tauri-plugin-vibrancy) ![official](https://img.shields.io/badge/-official-FFC131) - Make your Tauri/TAO windows vibrant.
 - [tauri-plugin-shadows](https://github.com/tauri-apps/tauri-plugin-shadows) ![official](https://img.shields.io/badge/-official-FFC131) -  Add native shadows to your Tauri/TAO windows.
 - [tauri-plugin-positioner](https://github.com/JonasKruckenberg/tauri-plugin-positioner) - Move windows to common locations.
- 
+
 ## Integrations
 
 - [vue-cli-plugin-tauri](https://github.com/tauri-apps/vue-cli-plugin-tauri) ![official](https://img.shields.io/badge/-official-FFC131) - Turn your Vue SPA into a lightweight cross-platform desktop app.


### PR DESCRIPTION
A bunch of changes to the guidelines and README.

To avoid confusion (and people skipping stuff), `CONTRIBUTING.md` has the same content as the pull request template. It might be a little weird this way, but it makes the process way easier. There's still 14 different guidelines just to add an app, but it's better than the 30 you had to read previously.

Some guidelines were combined or removed when another guideline already pretty much covered it.