### PR TITLE
Shorter commit signing guideline

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -15,9 +15,7 @@ Ensure your pull request adheres to the following guidelines:
 - Check your spelling and grammar.
 - Make sure your text editor is set to remove trailing whitespace.
 - New categories or improvements to the existing categorization are welcome, but should be done in a separate pull request.
-- We only accept *signed commits*, so sign your commits! 
-   <br> [Here is a great guide](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) that walks you through all the required steps.
-  > Note: Despite what the guide claims, GitHub Desktop honors the repo/system wide git config, so after running `git config --global commit.gpgsign true` GitHub Desktop will sign commits as well.
+- You have to [sign your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
 
 
 Thank you for your suggestion!


### PR DESCRIPTION
Shorter commit signing guideline to make contributing easier. I updated the GitHub commit signing guide to avoid needing the note about GitHub Desktop:
![image](https://user-images.githubusercontent.com/11315492/154008972-bbf34879-ed0d-48bf-a630-63efc93300f0.png)
