### PR TITLE
fix(link): add link text to template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+This is the link to the project: [TITLE](URL)
+
 - [ ] **I have read the [contributing guidelines](contributing.md).**
 
 - [ ] Title as described.


### PR DESCRIPTION
This PR merely asks the contributor to add the project link to the PR. I have countless times clicked on mobile through to the actual files and had to highlight the text. Would like to have it front and center for easy review.

- [x] **I have read the [contributing guidelines](contributing.md).**
