### PR TITLE
Add ngx-tauri to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [axios-tauri-adapter](https://git.kaki87.net/KaKi87/axios-tauri-adapter) - `axios` adapter for the `@tauri-apps/api/http` module.
 - [svelte-tauri-filedrop](https://github.com/probablykasper/svelte-tauri-filedrop) - File drop handling component for Svelte.
 - [Astrodon](https://github.com/astrodon/astrodon) - Make Tauri desktop apps with Deno 🦕
+- [ngx-tauri](https://codeberg.org/crapsilon/ngx-tauri) - Small lib to wrap arround functions from tauri modules, to integrate easier with Angular.
 
 ## Apps
 


### PR DESCRIPTION
Add "ngx-tauri" (npm package) a small lib to wrap arround functions from tauri modules, to integrate easier with Angular.

- [x] Title as described.
- [x] Added to the right category.
- [x] Added to the end of a list.
- [x] The description of your item is a sentence with less than 24 words.
- [x] No links and parentheses in description. 
- [x] The description starts with a capital and ends with a full stop/period.
- [x] The description doesn't start with `A` or `An`.
- [x] No unnecessary words already provided in the context (e.g. `for Tauri`, `a Tauri plugin`).
- [x] Uses proper case for terms (e.g. `GitHub`, `TypeScript`, `ESLint`, etc.)
- [x] When mentioning tools, omits versions whenever possible (e.g. use `TypeScript` instead of `TypeScript 4.x`.
- [x] When mentioning package names, uses quotes whenever possible.
- [x] The project is Open Source.
- [x] The readme is in English.