### PR TITLE
Align PR template with guidelines

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,6 +1,6 @@
 # Contribution Guidelines
 
-Make sure your pull request follows the guidelines/checklists in this document. Please note that entries can be removed if they do not follow the guidelines. Thank you for your suggestion!
+Make sure your pull request follows the guidelines/checklists in this document. Thank you for your suggestion!
 
 - Use the following format: `[Title](link) - Description.`
 - Add entries to the bottom of the correct category.
@@ -12,8 +12,8 @@ Make sure your pull request follows the guidelines/checklists in this document. 
 - Double-check spelling and grammar.
 - No trailing whitespace is added to the end of any file.
 - One suggestion per pull request.
-- Entries that repeatedly violate guidelines will be removed!
-- You have to [sign your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+- I understand that my entry will be removed if it violates the guidelines.
+- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 
 ## Plugins/Integrations
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-This is the link to the project: [TITLE](URL)
-
 - [ ] Use the following format: `[Title](link) - Description.`
 - [ ] Add entries to the bottom of the correct category.
 - [ ] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+Project link: https://...
+
 - [ ] Use the following format: `[Title](link) - Description.`
 - [ ] Add entries to the bottom of the correct category.
 - [ ] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,5 @@
 This is the link to the project: [TITLE](URL)
 
-- [ ] **I have read the [contributing guidelines](contributing.md).**
 - [ ] Use the following format: `[Title](link) - Description.`
 - [ ] Add entries to the bottom of the correct category.
 - [ ] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
@@ -12,7 +11,7 @@ This is the link to the project: [TITLE](URL)
 - [ ] No trailing whitespace is added to the end of any file.
 - [ ] One suggestion per pull request.
 - [ ] I understand that my entry will be removed if it violates the guidelines.
-- [ ] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+- [ ] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 
 ### Plugins/Integrations
 


### PR DESCRIPTION
The main point of the updates I made to the PR template/guidelines is so they're actually identical, which means there's potentially 2x less stuff you need to read. So in this one I made them identical again, and removed the checklist entry about reading the guidelines, since the PR template already covers it.

cc @JonasKruckenberg 