### PR TITLE
add tauri-vue-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 ## Templates
 - [tauri-svelte-template](https://github.com/probablykasper/tauri-svelte-template) - Svelte template with cross-platform GitHub action builds, Vite, TypeScript, Svelte Preprocess, hot module replacement, ESLint and Prettier.
 - [tauri-react-template](https://github.com/oSethoum/tauri-react-template) - React template with Vite, TypeScript, hot module replacement. 
+- [tauri-vue-template](https://github.com/Uninen/tauri-vue-template) - Vue template with TypeScript, Vite + HMR, Vitest, Tailwind CSS, ESLint, and GitHub Actions.
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 ## Templates
 - [tauri-svelte-template](https://github.com/probablykasper/tauri-svelte-template) - Svelte template with cross-platform GitHub action builds, Vite, TypeScript, Svelte Preprocess, hot module replacement, ESLint and Prettier.
 - [tauri-react-template](https://github.com/oSethoum/tauri-react-template) - React template with Vite, TypeScript, hot module replacement. 
-- [tauri-deno-starter](https://github.com/marc2332/tauri-deno-starter) - React template using esbuild with Deno. 
+- [tauri-deno-starter](https://github.com/marc2332/tauri-deno-starter) - React template using esbuild with Deno.
 - [tauri-vue-template](https://github.com/Uninen/tauri-vue-template) - Vue template with TypeScript, Vite + HMR, Vitest, Tailwind CSS, ESLint, and GitHub Actions.
 
 ## Plugins

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 
 ## Templates
 - [tauri-svelte-template](https://github.com/probablykasper/tauri-svelte-template) - Svelte template with cross-platform GitHub action builds, Vite, TypeScript, Svelte Preprocess, hot module replacement, ESLint and Prettier.
-- [tauri-react-template](https://github.com/oSethoum/tauri-react-template) - React template with Vite, TypeScript, hot module replacement. 
+- [tauri-react-template](https://github.com/oSethoum/tauri-react-template) - React template with Vite, TypeScript, hot module replacement.
 - [tauri-deno-starter](https://github.com/marc2332/tauri-deno-starter) - React template using esbuild with Deno.
 - [tauri-vue-template](https://github.com/Uninen/tauri-vue-template) - Vue template with TypeScript, Vite + HMR, Vitest, Tailwind CSS, ESLint, and GitHub Actions.
 


### PR DESCRIPTION
This is the link to the project: [tauri-vue-template](https://github.com/Uninen/tauri-vue-template)

- [x] **I have read the [contributing guidelines](contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] Add entries to the bottom of the correct category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [x] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).

### Templates

<!-- Ignore unless you're contributing to Templates -->

- [x] Works with **Tauri 1.x and onward**.
- [x] The repo is at least 30 days old.
- [x] Documentation is in English.
- [x] The template provides enough information about how to get started and what's included.
- [x] The template is pretty different from the existing templates.
