### PR TITLE
Added DevBox to closed source apps in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 ### Closed Source
 
 - [TimeChunks](https://danielulrich.com/en/timechunks/) - Time tracking for freelancers without timers and HH:MM:SS inputs.
-- [DevBox](https://www.dev-box.app/) - A lot of usefull tools for developers like generators, viewers, converters etc...
+- [DevBox](https://www.dev-box.app/) - A lot of useful tools for developers like generators, viewers, converters etc...
 
 ## Tutorials
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 ### Closed Source
 
 - [TimeChunks](https://danielulrich.com/en/timechunks/) - Time tracking for freelancers without timers and HH:MM:SS inputs.
-- [DevBox](https://www.dev-box.app/) - A lot of useful tools for developers like generators, viewers, converters etc...
+- [DevBox](https://www.dev-box.app/) - Many useful tools for developers, like generators, viewers, converters, etc...
 
 ## Tutorials
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 ### Closed Source
 
 - [TimeChunks](https://danielulrich.com/en/timechunks/) - Time tracking for freelancers without timers and HH:MM:SS inputs.
+- [DevBox](https://www.dev-box.app/) - A lot of usefull tools for developers like generators, viewers, converters etc...
 
 ## Tutorials
 


### PR DESCRIPTION
This is the link to the project: [TITLE](URL)

- [x] **I have read the [contributing guidelines](contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] Add entries to the bottom of the correct category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [ ] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [x] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).

### Plugins/Integrations

<!-- Ignore unless you're contributing to Plugins/Integrations -->

- [ ] Works with **Tauri 1.x and onward**.
- [ ] The project is open source and accepts contributions.
- [ ] The repo is at least 30 days old.
- [ ] Documentation is in English.
- [ ] The project is active and maintained.

### Templates

<!-- Ignore unless you're contributing to Templates -->

- [ ] Works with **Tauri 1.x and onward**.
- [ ] The repo is at least 30 days old.
- [ ] Documentation is in English.
- [ ] The template provides enough information about how to get started and what's included.
- [ ] The template is pretty different from the existing templates.

### Apps

<!-- Ignore unless you're contributing to Apps -->

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure.
- [x] If the app closed source, evidence of it being built with Tauri is included.

### Additional Context
Evidence is in the bottom of the page:
![image](https://user-images.githubusercontent.com/302692/175302108-57a9b4df-292a-4ef9-bb29-167dbe7c3588.png)
