### PR TITLE
Add tauri-clojurescript-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-rescript-template](https://github.com/JonasKruckenberg/tauri-rescript-template) - Tauri, ReScript, and React template.
 - [tauri-sycamore-template](https://github.com/JonasKruckenberg/tauri-sycamore-template) - Tauri and Sycamore template.
 - [tauri-solid-ts-tailwind-vite-template](https://github.com/AR10Dev/tauri-solid-ts-tailwind-vite) - SolidJS Template preconfigured to use Vite, TypeScript, Tailwind CSS, ESLint and Prettier.
+- [tauri-clojurescript-template](https://github.com/rome-user/tauri-clojurescript-template) - Minimal ClojureScript template with Shadow CLJS and React.
 
 ## Plugins
 


### PR DESCRIPTION
This is the link to the project: [tauri-clojurescript-template](https://github.com/rome-user/tauri-clojurescript-template)

- [x] **I have read the [contributing guidelines](contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] Add entries to the bottom of the correct category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [x] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).

### Plugins/Integrations

<!-- Ignore unless you're contributing to Plugins/Integrations -->

- [ ] Works with **Tauri 1.x and onward**.
- [ ] The project is open source and accepts contributions.
- [ ] The repo is at least 30 days old.
- [ ] Documentation is in English.
- [ ] The project is active and maintained.

### Templates

<!-- Ignore unless you're contributing to Templates -->

- [x] Works with **Tauri 1.x and onward**.
- [ ] The repo is at least 30 days old.
- [x] Documentation is in English.
- [x] The template provides enough information about how to get started and what's included.
- [x] The template is pretty different from the existing templates.

### Apps

<!-- Ignore unless you're contributing to Apps -->

- [ ] The app is original and not too simple.
- [ ] The README is in English.
- [ ] The app makes a reasonable effort to be fast, lightweight and secure.
- [ ] If the app closed source, evidence of it being built with Tauri is included.

### Additional Context
Tested on macOS with Node.js 18. If there is a hard requirement on the repository age, please mark this PR as draft so we can revisit later. Thank you.