### PR TITLE
Update README.md to include the Tauri Mobile project

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [QuickGPT](https://github.com/dubisdev/quickgpt) - Lightweight AI assistant for Windows.
 - [Gitification](https://github.com/Gitification-App/gitification) - Menu bar app for managing Github notifications.
 - [ChatGPT App](https://github.com/Poordeveloper/chatgpt-app) - Cross-platform ChatGPT App and more.
+- [Tauri Mobile Test](https://github.com/dedSyn4ps3/tauri-mobile-test) - Create and build cross-platform mobile applications.
 
 ### Closed Source
 
@@ -156,6 +157,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 
 ## Articles
 - [Tauri's async process](https://rfdonnelly.github.io/posts/tauri-async-rust-process/) - Rob Donnelly dives deep into Async with Tauri
+- [Getting Started Using Tauri Mobile](https://medium.com/@erutherford_nullreturn) - Ed Rutherford outlines how to create a mobile app with Tauri
 
 
 [officially maintained]: https://img.shields.io/badge/official-FFC131?&logo=tauri&logoColor=black


### PR DESCRIPTION
This is the link to the project: [Tauri Mobile Test](https://github.com/dedSyn4ps3/tauri-mobile-test)

- [x] **I have read the [contributing guidelines](contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] Add entries to the bottom of the correct category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [x] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).

### Plugins/Integrations

<!-- Ignore unless you're contributing to Plugins/Integrations -->

- [ ] Works with **Tauri 1.x and onward**.
- [ ] The project is open source and accepts contributions.
- [ ] The repo is at least 30 days old.
- [ ] Documentation is in English.
- [ ] The project is active and maintained.

### Templates

<!-- Ignore unless you're contributing to Templates -->

- [ ] Works with **Tauri 1.x and onward**.
- [ ] The repo is at least 30 days old.
- [ ] Documentation is in English.
- [ ] The template provides enough information about how to get started and what's included.
- [ ] The template is pretty different from the existing templates.

### Apps

<!-- Ignore unless you're contributing to Apps -->

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure.
- [x] If the app closed source, evidence of it being built with Tauri is included.

### Additional Context
- Project goes with companion article published on [Medium](https://medium.com/@erutherford_nullreturn).
