### PR TITLE
Restructuring of README.md for use with a TOC

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -2,8 +2,12 @@
 
 Make sure your pull request follows the guidelines/checklists in this document. Please note that entries can be removed if they do not follow the guidelines. Thank you for your suggestion!
 
+All projects are assumed to be free and open source unless otherwise specified using the appropriate badges to indicate otherwise.
+
 - Use the following format: `[Title](link) - Description.`
-- Add entries to the bottom of the correct category.
+- If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
+- If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
+- Add entries alphabetically to the most appropriate category.
 - No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
 - Description does not start with `A` or `An`.
 - Description is under 24 words.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@ This is the link to the project: [TITLE](URL)
 
 - [ ] **I have read the [contributing guidelines](contributing.md).**
 - [ ] Use the following format: `[Title](link) - Description.`
+- [ ] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
+- [ ] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
 - [ ] Add entries to the bottom of the correct category.
 - [ ] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
 - [ ] Description does not start with `A` or `An`.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,60 @@
-<!--lint disable awesome-heading awesome-github awesome-toc double-link -->
+<!--lint disable awesome-heading awesome-toc awesome-github double-link -->
 
-<h1 align='center'>Awesome Tauri</h1>
+<div align="center">
+<h1>Awesome Tauri</h1>
 
-<p align='center'>
 A curated collection of the best stuff from the Tauri ecosystem and community.
-<br><br>
 
-<a href='https://awesome.re'>
-<img src='https://awesome.re/badge-flat.svg' alt='Awesome'>
-</a>
-</p>
+<br />
+
+[![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)
+
+</div>
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+  - [Guides](#guides)
+  - [Tutorials](#tutorials)
+  - [Templates](#templates)
+- [Development](#development)
+  - [Plugins](#plugins)
+  - [Integrations](#integrations)
+- [Further Reading](#further-reading)
+  - [Articles](#articles)
+- [Applications](#applications)
+  - [Audio & Video](#audio--video)
+  - [ChatGPT clients](#chatgpt-clients)
+  - [Data](#data)
+  - [Developer tools](#developer-tools)
+  - [Email & Feeds](#email--feeds)
+  - [File management](#file-management)
+  - [Finance](#finance)
+  - [Gaming](#gaming)
+  - [Information](#information)
+  - [Learning](#learning)
+  - [Networking](#networking)
+  - [Office & Writing](#office--writing)
+  - [Productivity](#productivity)
+  - [Security](#security)
+  - [Social media](#social-media)
+  - [Utilities](#utilities)
 
 ## Getting Started
 
-- [Introduction](https://tauri.app/about/intro/) - Official introduction to Tauri.
-- [Getting Started](https://tauri.app/v1/guides/getting-started/prerequisites/) - Official getting started with Tauri docs.
-- [create-tauri-app](https://github.com/tauri-apps/create-tauri-app) - Rapidly scaffold your Tauri app.
+### Guides
 
-## Templates
+- [Introduction](https://tauri.app/about/intro/) ![officially maintained] - Official introduction to Tauri.
+- [Getting Started](https://tauri.app/v1/guides/getting-started/prerequisites/) ![officially maintained] - Official getting started with Tauri docs.
+- [create-tauri-app](https://github.com/tauri-apps/create-tauri-app) ![officially maintained] - Rapidly scaffold your Tauri app.
+
+### Tutorials
+
+- [Create Tauri App with React](https://www.youtube.com/watch?v=zawhqLA7N9Y&ab_channel=chrisbiscardi) - Chris Biscardi shows how easy it is to wire up a Rust crate with a JS module and communicate between them.
+- [Publish to Apple's App Store](https://thinkgo.io/post/2023/02/publish_tauri_to_apples_app_store/) - Details all the steps needed to publish your Mac app to the app store. Includes a sample bash script.
+- [Tauri & ReactJS - Creating Modern Desktop Apps](https://youtube.com/playlist?list=PLmWYh0f8jKSjt9VC5sq2T3mFETasG2p2L) - Creating a modern desktop application with Tauri.
+
+### Templates
 
 - [tauri-svelte-template](https://github.com/probablykasper/tauri-svelte-template) - Svelte template with cross-platform GitHub action builds, Vite, TypeScript, Svelte Preprocess, hot module replacement, ESLint and Prettier.
 - [tauri-react-template](https://github.com/oSethoum/tauri-react-template) - React template with Vite, TypeScript, hot module replacement.
@@ -30,7 +67,9 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-solid-ts-tailwind-vite-template](https://github.com/AR10Dev/tauri-solid-ts-tailwind-vite) - SolidJS Template preconfigured to use Vite, TypeScript, Tailwind CSS, ESLint and Prettier.
 - [tauri-clojurescript-template](https://github.com/rome-user/tauri-clojurescript-template) - Minimal ClojureScript template with Shadow CLJS and React.
 
-## Plugins
+## Development
+
+### Plugins
 
 - [tauri-plugin-authenticator](https://github.com/tauri-apps/tauri-plugin-authenticator) ![officially maintained] - Interface with hardware security keys.
 - [tauri-plugin-log](https://github.com/tauri-apps/tauri-plugin-log) ![officially maintained] - Configurable logging.
@@ -47,7 +86,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-plugin-aptabase](https://github.com/aptabase/tauri-plugin-aptabase) - Privacy-first and minimalist analytics for desktop and mobile apps.
 - [tauri-plugin-clipboard](https://github.com/CrossCopy/tauri-plugin-clipboard) - Clipboard plugin for reading/writing clipboard text/image, and monitoring clipboard update.
 
-## Integrations
+### Integrations
 
 - [vue-cli-plugin-tauri](https://github.com/tauri-apps/vue-cli-plugin-tauri) ![officially maintained] - Turn your Vue SPA into a lightweight cross-platform desktop app.
 - [vite-plugin-tauri](https://github.com/amrbashir/vite-plugin-tauri) - Integrate Tauri in a Vite project to build cross-platform apps.
@@ -59,103 +98,141 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [axios-tauri-api-adapter](https://github.com/persiliao/axios-tauri-api-adapter) - Makes it easy to use Axios in Tauri, `axios` adapter for the `@tauri-apps/api/http` module.
 - [tauri-update-server](https://git.kaki87.net/KaKi87/tauri-update-server) - Automatically interface the Tauri updater with git repository releases.
 
-## Apps
+### Articles
 
-### Open Source
-
-- [UsTaxes](https://github.com/ustaxes/ustaxes) - Free, private, open-source US tax filings.
-- [Xplorer](https://github.com/kimlimjustin/xplorer) - Customizable, modern and cross-platform File Explorer.
-- [Clash Verge](https://github.com/zzzgydi/clash-verge) - Rule based proxy for Linux, Mac and Windows based on `clash`.
-- [Authme](https://github.com/Levminer/authme) - Two-factor (2FA) authentication app for desktop.
-- [BS Redis Desktop Client](https://github.com/fuyoo/bs-redis-desktop-client) - The Best Surprise Redis Desktop Client.
-- [Kadium](https://github.com/probablykasper/kadium) - App for staying on top of YouTube channel uploads.
-- [Mr Tagger](https://github.com/probablykasper/mr-tagger) - Music file tagging app.
-- [Time Machine Inspector](https://github.com/probablykasper/time-machine-inspector) - Find out what's taking up your Time Machine backup space.
-- [Identia](https://github.com/iohzrd/identia) - Decentralized social media on IPFS.
-- [Calciumdibromid](https://codeberg.org/Calciumdibromid/CaBr2) - Generate "experiment wise safety sheets" in compliance to European law.
-- [Watcher](https://github.com/windht/watcher) - API manager built for a easier use to manage and collaborate.
-- [FishLauncher](https://github.com/fishfight/FishLauncher) - Cross-platform launcher for `Fish Fight`.
-- [Mail-Dev](https://github.com/samirdjelal/mail-dev) - Cross-platform, local SMTP server for email testing/debugging.
-- [Bidirectional](https://github.com/samirdjelal/bidirectional) - Write Arabic text in apps that don't support bidirectional text.
-- [CubeShuffle](https://github.com/philipborg/CubeShuffle) - Card game shuffling utility.
-- [Echoo](https://github.com/zsmatrix62/echoo-app) - Offline/Online utilities for developers on MacOS & Windows.
-- [Orange](https://github.com/naaive/orange) - Cross-platform file search engine that can quickly locate files or folders based on keywords.
-- [mediarepo](https://github.com/Trivernis/mediarepo) - Tag-based media management application.
-- [nym-wallet](https://github.com/nymtech/nym/tree/develop/nym-wallet) - The Nym desktop wallet enables you to use the Nym network and take advantage of its key capabilities.
-- [mdsilo Desktop](https://github.com/mdSilo/mdSilo-app) - feed reader and knowledge base.
-- [Aleph](https://github.com/chezhe/aleph) - Aleph is an RSS reader & podcast client.
-- [MBTiles Viewer](https://github.com/Akylas/mbview-rs) - MBTiles Viewer and Inspector.
-- [Tauthy](https://github.com/pwltr/tauthy) - Cross-platform TOTP authentication client. 
-- [Douyin Downloader](https://github.com/lzdyes/douyin-downloader) - Cross-platform douyin video downloader.
-- [Pointless](https://github.com/kkoomen/pointless) - Endless drawing canvas.
-- [AppCenter Companion](https://github.com/zenoxs/tauri-appcenter-companion) - Regroup, build and track your `VS App Center` apps.
-- [Compotes](https://github.com/Orbitale/Compotes) - Local bank account operations storage to vizualize them as graphs and customize them with rules and tags for better filtering.
-- [Piano Trainer](https://github.com/ZaneH/piano-trainer) - Practice piano chords, scales, and more using your MIDI keyboard.
-- [Blank](https://github.com/FPurchess/blank) - Minimalistic, opinionated markdown editor made for writing.
-- [Remind Me Again](https://github.com/probablykasper/remind-me-again) - Toggleable reminders app for Mac, Linux and Windows.
-- [Stockman](https://github.com/awkj/stockman) - Display stock info on mac menubar.
-- [CryptoBal](https://github.com/Rabbit-Company/CryptoBal-Desktop) - Desktop application for monitoring your crypto assets.
-- [Spacedrive](https://github.com/spacedriveapp/spacedrive) - A file explorer from the future.
-- [Padloc](https://github.com/padloc/padloc) - Modern, open source password manager for individuals and teams.
-- [Ghorbu Wallet](https://github.com/matthias-wright/ghorbu-wallet) - Cross-platform desktop HD wallet for Bitcoin.
-- [Stable Diffusion Buddy](https://github.com/breadthe/sd-buddy) - Desktop UI companion for the self-hosted Mac version of Stable Diffusion.
-- [Lettura](https://github.com/zhanglun/lettura) - Open-source feed reader for macOS.
-- [Clipboard Record](https://github.com/lesterhnu/clipboard) - Record Clipboard Content.
-- [Scraper Instagram GUI Desktop](https://git.kaki87.net/KaKi87/scraper-instagram-gui-desktop) - Alternative Instagram front-end for desktop.
-- [CyberAPI](https://github.com/vicanso/cyberapi) - API tool client for developer.
-- [Link Saas](https://github.com/linksaas/desktop) - Efficiency tools for software development teams.
-- [Dropcode](https://github.com/egoist/dropcode) - Simple and lightweight code snippet manager.
-- [JournalV](https://github.com/ahmedkapro/journalv) - Journaling app for your days and dreams.
-- [GitBar](https://github.com/mikaelkristiansson/gitbar) - System tray app for GitHub reviews.
-- [Wirefish](https://github.com/stefanodevenuto/wirefish) - Cross-platform packet sniffer and analyzer.
-- [Kanri](https://github.com/trobonox/kanri) - Cross-platform, offline-first Kanban board app with a focus on simplicity and user experience.
-- [Jexpe](https://github.com/jexpe-apps/jexpe) - Cross-platform, open source SSH and SFTP client that makes connecting to your remote servers easy.
-- [Lanaya](https://github.com/ChurchTao/Lanaya) - Easy to use, cross-platform clipboard management.
-- [SquirrelDisk](https://github.com/adileo/squirreldisk) - Beautiful cross-platform disk usage analysis tool.
-- [Curses](https://github.com/mmpneo/curses) - Speech-to-Text and Text-to-Speech captions for OBS, VRChat, Twitch chat and more.
-- [RustDesk](https://github.com/rustdesk/rustdesk-server) - Self-hosted server for RustDesk, an open source remote desktop.
-- [Manjaro Starter](https://github.com/oguzkaganeren/manjaro-starter) - Documentation and support app for new Manjaro users.
-- [Verve](https://github.com/ParthJadhav/verve) - Launcher for accessing and opening applications, files and documents.
-- [RunMath](https://github.com/dubisdev/runmath) - Keyboard-first calculator for Windows.
-- [Spyglass](https://github.com/a5huynh/spyglass) - Personal search engine that indexes your files/folders, cloud accounts, and whatever interests you on the internet.
-- [Seismic](https://github.com/breadthe/seismic) - Taskbar app for USGS earthquake tracking.
-- [TunnlTo](https://github.com/TunnlTo/desktop-app) - Windows WireGuard VPN client built for split tunneling.
-- [ChatGPT](https://github.com/lencx/ChatGPT) - Cross-platform ChatGPT desktop application.
-- [Pake](https://github.com/tw93/Pake) - Turn any webpage into a desktop app with Rust with ease.
-- [BuildLog](https://github.com/rajatkulkarni95/buildlog) - Menu bar for keeping track of Vercel Deployments.
-- [ToeRings](https://github.com/acarl005/toerings) - Conky Seamod inspired system monitor app.
-- [enassi](https://github.com/enassi/enassi) - Encryption assistant that encrypts and stores your notes and files.
-- [chatbox](https://github.com/Bin-Huang/chatbox) - Cross-platform desktop application for ChatGPT API (OpenAI API), also a prompt debugging and management tool.
-- [En Croissant](https://github.com/franciscoBSalgueiro/en-croissant) - Chess database and game analysis app.
-- [Steam Art Manager](https://github.com/Tormak9970/Steam-Art-Manager) - Tool for customizing the art of your Steam games.
-- [ChatGPT-Desktop](https://github.com/Synaptrix/ChatGPT-Desktop) - Cross-platform productivity ChatGPT assistant launcher.
-- [EzUp](https://github.com/HuakunShen/ezup) - File and Image uploader. Designed for blog writing and note taking.
-- [SensiMouse](https://github.com/Nicify/sensi-mouse) - Easily change macOS system-wide mouse sensitivity and acceleration settings.
-- [Pavo](https://github.com/zhanglun/pavo) - Cross-platform desktop wallpaper application.
-- [QuickGPT](https://github.com/dubisdev/quickgpt) - Lightweight AI assistant for Windows.
-- [Gitification](https://github.com/Gitification-App/gitification) - Menu bar app for managing Github notifications.
-- [ChatGPT App](https://github.com/Poordeveloper/chatgpt-app) - Cross-platform ChatGPT App and more.
-
-### Closed Source
-
-- [TimeChunks](https://danielulrich.com/en/timechunks/) - Time tracking for freelancers without timers and HH:MM:SS inputs.
-- [DevBox](https://www.dev-box.app/) - Many useful tools for developers, like generators, viewers, converters, etc.
-- [Payload](https://payload.app/) - Drag & drop file transfers over local networks.
-- [Aptakube](https://aptakube.com/) - Multi-cluster Kubernetes UI.
-- [Hypetrigger](https://hypetrigger.io/) - Detect highlight clips in video with FFMPEG + Tensorflow on the GPU.
-- [Semanmeter](https://yibiao.fun/) - OCR and document conversion software.
-- [BULKUS](https://mailvalidator.online/) - Email validation software.
-- [Ensō](https://enso.sonnet.io) - Write now, edit later. Ensō is a writing tool that helps you enter a state of flow.
-- [Cider](https://cider.sh) - 3rd Party Client for Apple Music, Complete with Audio Lab.
-
-## Tutorials
-
-- [Create Tauri App with React](https://www.youtube.com/watch?v=zawhqLA7N9Y&ab_channel=chrisbiscardi) - Chris Biscardi shows how easy it is to wire up a Rust crate with a JS module and communicate between them.
-- [Publish to Apple's App Store](https://thinkgo.io/post/2023/02/publish_tauri_to_apples_app_store/) - Details all the steps needed to publish your Mac app to the app store. Includes a sample bash script.
-- [Tauri & ReactJS - Creating Modern Desktop Apps](https://youtube.com/playlist?list=PLmWYh0f8jKSjt9VC5sq2T3mFETasG2p2L) - Creating a modern desktop application with Tauri.
-
-## Articles
 - [Tauri's async process](https://rfdonnelly.github.io/posts/tauri-async-rust-process/) - Rob Donnelly dives deep into Async with Tauri
 
-
 [officially maintained]: https://img.shields.io/badge/official-FFC131?&logo=tauri&logoColor=black
+[closed source]: https://img.shields.io/badge/closed%20source-FFC131?&logoColor=black
+[paid]: https://img.shields.io/badge/paid-FFC131?&logoColor=black
+
+## Applications
+
+### Audio & Video
+
+- [Cider](https://cider.sh) ![closed source] - 3rd Party Client for Apple Music, Complete with Audio Lab.
+- [Curses](https://github.com/mmpneo/curses) - Speech-to-Text and Text-to-Speech captions for OBS, VRChat, Twitch chat and more.
+- [Douyin Downloader](https://github.com/lzdyes/douyin-downloader) - Cross-platform douyin video downloader.
+- [Hypetrigger](https://hypetrigger.io/) ![closed source] - Detect highlight clips in video with FFMPEG + Tensorflow on the GPU.
+- [mediarepo](https://github.com/Trivernis/mediarepo) - Tag-based media management application.
+- [Mr Tagger](https://github.com/probablykasper/mr-tagger) - Music file tagging app.
+
+### ChatGPT clients
+
+- [chatbox](https://github.com/Bin-Huang/chatbox) - Cross-platform desktop application for ChatGPT API (OpenAI API), also a prompt debugging and management tool.
+- [ChatGPT](https://github.com/lencx/ChatGPT) - Cross-platform ChatGPT desktop application.
+- [ChatGPT App](https://github.com/Poordeveloper/chatgpt-app) - Cross-platform ChatGPT App and more.
+- [ChatGPT-Desktop](https://github.com/Synaptrix/ChatGPT-Desktop) - Cross-platform productivity ChatGPT assistant launcher.
+- [QuickGPT](https://github.com/dubisdev/quickgpt) - Lightweight AI assistant for Windows.
+
+### Data
+
+- [BS Redis Desktop Client](https://github.com/fuyoo/bs-redis-desktop-client) - The Best Surprise Redis Desktop Client.
+
+### Developer tools
+
+- [AppCenter Companion](https://github.com/zenoxs/tauri-appcenter-companion) - Regroup, build and track your `VS App Center` apps.
+- [Aptakube](https://aptakube.com/) ![closed source] - Multi-cluster Kubernetes UI.
+- [DevBox](https://www.dev-box.app/) ![closed source] - Many useful tools for developers, like generators, viewers, converters, etc.
+- [Dropcode](https://github.com/egoist/dropcode) - Simple and lightweight code snippet manager.
+- [Echoo](https://github.com/zsmatrix62/echoo-app) - Offline/Online utilities for developers on MacOS & Windows.
+- [Pake](https://github.com/tw93/Pake) - Turn any webpage into a desktop app with Rust with ease.
+
+### Email & Feeds
+
+- [Aleph](https://github.com/chezhe/aleph) - Aleph is an RSS reader & podcast client.
+- [BULKUS](https://mailvalidator.online/) ![closed source] - Email validation software.
+- [Lettura](https://github.com/zhanglun/lettura) - Open-source feed reader for macOS.
+- [mdsilo Desktop](https://github.com/mdSilo/mdSilo-app) - feed reader and knowledge base.
+
+### File management
+
+- [enassi](https://github.com/enassi/enassi) - Encryption assistant that encrypts and stores your notes and files.
+- [EzUp](https://github.com/HuakunShen/ezup) - File and Image uploader. Designed for blog writing and note taking.
+- [Orange](https://github.com/naaive/orange) - Cross-platform file search engine that can quickly locate files or folders based on keywords.
+- [Payload](https://payload.app/) ![closed source] - Drag & drop file transfers over local networks.
+- [Spacedrive](https://github.com/spacedriveapp/spacedrive) - A file explorer from the future.
+- [Spyglass](https://github.com/a5huynh/spyglass) - Personal search engine that indexes your files/folders, cloud accounts, and whatever interests you on the internet.
+- [SquirrelDisk](https://github.com/adileo/squirreldisk) - Beautiful cross-platform disk usage analysis tool.
+- [Time Machine Inspector](https://github.com/probablykasper/time-machine-inspector) - Find out what's taking up your Time Machine backup space.
+- [Xplorer](https://github.com/kimlimjustin/xplorer) - Customizable, modern and cross-platform File Explorer.
+
+### Finance
+
+- [Compotes](https://github.com/Orbitale/Compotes) - Local bank account operations storage to vizualize them as graphs and customize them with rules and tags for better filtering.
+- [CryptoBal](https://github.com/Rabbit-Company/CryptoBal-Desktop) - Desktop application for monitoring your crypto assets.
+- [Ghorbu Wallet](https://github.com/matthias-wright/ghorbu-wallet) - Cross-platform desktop HD wallet for Bitcoin.
+- [nym-wallet](https://github.com/nymtech/nym/tree/develop/nym-wallet) - The Nym desktop wallet enables you to use the Nym network and take advantage of its key capabilities.
+- [UsTaxes](https://github.com/ustaxes/ustaxes) - Free, private, open-source US tax filings.
+
+### Gaming
+
+- [CubeShuffle](https://github.com/philipborg/CubeShuffle) - Card game shuffling utility.
+- [En Croissant](https://github.com/franciscoBSalgueiro/en-croissant) - Chess database and game analysis app.
+- [FishLauncher](https://github.com/fishfight/FishLauncher) - Cross-platform launcher for `Fish Fight`.
+- [Steam Art Manager](https://github.com/Tormak9970/Steam-Art-Manager) - Tool for customizing the art of your Steam games.
+
+### Information
+
+- [Seismic](https://github.com/breadthe/seismic) - Taskbar app for USGS earthquake tracking.
+- [Stockman](https://github.com/awkj/stockman) - Display stock info on mac menubar.
+
+### Learning
+
+- [Manjaro Starter](https://github.com/oguzkaganeren/manjaro-starter) - Documentation and support app for new Manjaro users.
+- [Piano Trainer](https://github.com/ZaneH/piano-trainer) - Practice piano chords, scales, and more using your MIDI keyboard.
+
+### Networking
+
+- [Clash Verge](https://github.com/zzzgydi/clash-verge) - Rule based proxy for Linux, Mac and Windows based on `clash`.
+- [CyberAPI](https://github.com/vicanso/cyberapi) - API tool client for developer.
+- [Jexpe](https://github.com/jexpe-apps/jexpe) - Cross-platform, open source SSH and SFTP client that makes connecting to your remote servers easy.
+- [Mail-Dev](https://github.com/samirdjelal/mail-dev) - Cross-platform, local SMTP server for email testing/debugging.
+- [RustDesk](https://github.com/rustdesk/rustdesk-server) - Self-hosted server for RustDesk, an open source remote desktop.
+- [TunnlTo](https://github.com/TunnlTo/desktop-app) - Windows WireGuard VPN client built for split tunneling.
+- [Watcher](https://github.com/windht/watcher) - API manager built for a easier use to manage and collaborate.
+- [Wirefish](https://github.com/stefanodevenuto/wirefish) - Cross-platform packet sniffer and analyzer.
+
+### Office & Writing
+
+- [Bidirectional](https://github.com/samirdjelal/bidirectional) - Write Arabic text in apps that don't support bidirectional text.
+- [Blank](https://github.com/FPurchess/blank) - Minimalistic, opinionated markdown editor made for writing.
+- [Ensō](https://enso.sonnet.io) ![closed source] - Write now, edit later. Ensō is a writing tool that helps you enter a state of flow.
+- [JournalV](https://github.com/ahmedkapro/journalv) - Journaling app for your days and dreams.
+- [Semanmeter](https://yibiao.fun/) ![closed source] - OCR and document conversion software.
+
+### Productivity
+
+- [BuildLog](https://github.com/rajatkulkarni95/buildlog) - Menu bar for keeping track of Vercel Deployments.
+- [GitBar](https://github.com/mikaelkristiansson/gitbar) - System tray app for GitHub reviews.
+- [Gitification](https://github.com/Gitification-App/gitification) - Menu bar app for managing Github notifications.
+- [Kanri](https://github.com/trobonox/kanri) - Cross-platform, offline-first Kanban board app with a focus on simplicity and user experience.
+- [Link Saas](https://github.com/linksaas/desktop) - Efficiency tools for software development teams.
+- [Remind Me Again](https://github.com/probablykasper/remind-me-again) - Toggleable reminders app for Mac, Linux and Windows.
+- [TimeChunks](https://danielulrich.com/en/timechunks/) ![closed source] - Time tracking for freelancers without timers and HH:MM:SS inputs.
+
+### Security
+
+- [Authme](https://github.com/Levminer/authme) - Two-factor (2FA) authentication app for desktop.
+- [Calciumdibromid](https://codeberg.org/Calciumdibromid/CaBr2) - Generate "experiment wise safety sheets" in compliance to European law.
+- [Padloc](https://github.com/padloc/padloc) - Modern, open source password manager for individuals and teams.
+- [Tauthy](https://github.com/pwltr/tauthy) - Cross-platform TOTP authentication client.
+
+### Social media
+
+- [Identia](https://github.com/iohzrd/identia) - Decentralized social media on IPFS.
+- [Kadium](https://github.com/probablykasper/kadium) - App for staying on top of YouTube channel uploads.
+- [Scraper Instagram GUI Desktop](https://git.kaki87.net/KaKi87/scraper-instagram-gui-desktop) - Alternative Instagram front-end for desktop.
+
+### Utilities
+
+- [Pavo](https://github.com/zhanglun/pavo) - Cross-platform desktop wallpaper application.
+- [SensiMouse](https://github.com/Nicify/sensi-mouse) - Easily change macOS system-wide mouse sensitivity and acceleration settings.
+- [ToeRings](https://github.com/acarl005/toerings) - Conky Seamod inspired system monitor app.
+- [MBTiles Viewer](https://github.com/Akylas/mbview-rs) - MBTiles Viewer and Inspector.
+- [Stable Diffusion Buddy](https://github.com/breadthe/sd-buddy) - Desktop UI companion for the self-hosted Mac version of Stable Diffusion.
+- [RunMath](https://github.com/dubisdev/runmath) - Keyboard-first calculator for Windows.
+- [Verve](https://github.com/ParthJadhav/verve) - Launcher for accessing and opening applications, files and documents.
+- [Lanaya](https://github.com/ChurchTao/Lanaya) - Easy to use, cross-platform clipboard management.
+- [Clipboard Record](https://github.com/lesterhnu/clipboard) - Record Clipboard Content.
+- [Pointless](https://github.com/kkoomen/pointless) - Endless drawing canvas.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Development](#development)
   - [Plugins](#plugins)
   - [Integrations](#integrations)
-- [Further Reading](#further-reading)
   - [Articles](#articles)
 - [Applications](#applications)
   - [Audio & Video](#audio--video)
@@ -101,10 +100,6 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 ### Articles
 
 - [Tauri's async process](https://rfdonnelly.github.io/posts/tauri-async-rust-process/) - Rob Donnelly dives deep into Async with Tauri
-
-[officially maintained]: https://img.shields.io/badge/official-FFC131?&logo=tauri&logoColor=black
-[closed source]: https://img.shields.io/badge/closed%20source-FFC131?&logoColor=black
-[paid]: https://img.shields.io/badge/paid-FFC131?&logoColor=black
 
 ## Applications
 
@@ -236,3 +231,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Lanaya](https://github.com/ChurchTao/Lanaya) - Easy to use, cross-platform clipboard management.
 - [Clipboard Record](https://github.com/lesterhnu/clipboard) - Record Clipboard Content.
 - [Pointless](https://github.com/kkoomen/pointless) - Endless drawing canvas.
+
+[officially maintained]: https://img.shields.io/badge/official-FFC131?&logo=tauri&logoColor=black
+[closed source]: https://img.shields.io/badge/closed%20source-FFC131?&logoColor=black
+[paid]: https://img.shields.io/badge/paid-FFC131?&logoColor=black

--- a/README.md
+++ b/README.md
@@ -221,16 +221,16 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 
 ### Utilities
 
-- [Pavo](https://github.com/zhanglun/pavo) - Cross-platform desktop wallpaper application.
-- [SensiMouse](https://github.com/Nicify/sensi-mouse) - Easily change macOS system-wide mouse sensitivity and acceleration settings.
-- [ToeRings](https://github.com/acarl005/toerings) - Conky Seamod inspired system monitor app.
-- [MBTiles Viewer](https://github.com/Akylas/mbview-rs) - MBTiles Viewer and Inspector.
-- [Stable Diffusion Buddy](https://github.com/breadthe/sd-buddy) - Desktop UI companion for the self-hosted Mac version of Stable Diffusion.
-- [RunMath](https://github.com/dubisdev/runmath) - Keyboard-first calculator for Windows.
-- [Verve](https://github.com/ParthJadhav/verve) - Launcher for accessing and opening applications, files and documents.
-- [Lanaya](https://github.com/ChurchTao/Lanaya) - Easy to use, cross-platform clipboard management.
 - [Clipboard Record](https://github.com/lesterhnu/clipboard) - Record Clipboard Content.
+- [Lanaya](https://github.com/ChurchTao/Lanaya) - Easy to use, cross-platform clipboard management.
+- [MBTiles Viewer](https://github.com/Akylas/mbview-rs) - MBTiles Viewer and Inspector.
+- [Pavo](https://github.com/zhanglun/pavo) - Cross-platform desktop wallpaper application.
 - [Pointless](https://github.com/kkoomen/pointless) - Endless drawing canvas.
+- [RunMath](https://github.com/dubisdev/runmath) - Keyboard-first calculator for Windows.
+- [SensiMouse](https://github.com/Nicify/sensi-mouse) - Easily change macOS system-wide mouse sensitivity and acceleration settings.
+- [Stable Diffusion Buddy](https://github.com/breadthe/sd-buddy) - Desktop UI companion for the self-hosted Mac version of Stable Diffusion.
+- [ToeRings](https://github.com/acarl005/toerings) - Conky Seamod inspired system monitor app.
+- [Verve](https://github.com/ParthJadhav/verve) - Launcher for accessing and opening applications, files and documents.
 
 [officially maintained]: https://img.shields.io/badge/official-FFC131?&logo=tauri&logoColor=black
 [closed source]: https://img.shields.io/badge/closed%20source-FFC131?&logoColor=black


### PR DESCRIPTION
The README has gotten large enough by now that it's almost impossible to effectively use it and navigate it. To remedy this I'm proposing the following restructuring to use a Table of Contents for easy navigation.

Instead of using entire separate sections for things that are paid of closed source I have added appropriate badges that can be added to entries. This saves a bunch of space and enhances readability. All entries are assumed to be **free and open source unless otherwise specified with badges**.

I've also reordered all entries so that they are alphabetically sorted.