### PR TITLE
Add Alduin in email and feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 
 ### Email & Feeds
 
+- [Alduin](https://alduin.stouder.io/) - Alduin is a free and open source RSS, Atom and JSON feed reader that allows you to keep track of your favorite websites.
 - [Aleph](https://github.com/chezhe/aleph) - Aleph is an RSS reader & podcast client.
 - [BULKUS](https://mailvalidator.online/) ![closed source] - Email validation software.
 - [Lettura](https://github.com/zhanglun/lettura) - Open-source feed reader for macOS.


### PR DESCRIPTION
This is the link to the project: [TITLE](URL)

- [x] **I have read the [contributing guidelines](contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
- [x] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [x] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).

### Plugins/Integrations

<!-- Ignore unless you're contributing to Plugins/Integrations -->

- [ ] Works with **Tauri 1.x and onward**.
- [ ] The project is open source and accepts contributions.
- [ ] The repo is at least 30 days old.
- [ ] Documentation is in English.
- [ ] The project is active and maintained.

### Templates

<!-- Ignore unless you're contributing to Templates -->

- [ ] Works with **Tauri 1.x and onward**.
- [ ] The repo is at least 30 days old.
- [ ] Documentation is in English.
- [ ] The template provides enough information about how to get started and what's included.
- [ ] The template is pretty different from the existing templates.

### Apps

<!-- Ignore unless you're contributing to Apps -->

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure.
- [x] If the app closed source, evidence of it being built with Tauri is included.

### Additional Context
I've fully rewritten Alduin from Electron to Tauri, let me know I something is wrong with adding it here.