### PR TITLE
fix: Use full url for link to contributing guidelines, fixes #238

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 This is the link to the project: [TITLE](URL)
 
-- [ ] **I have read the [contributing guidelines](contributing.md).**
+- [ ] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
 - [ ] Use the following format: `[Title](link) - Description.`
 - [ ] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
 - [ ] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.


### PR DESCRIPTION
Changes this:
- [ ] **I have read the [contributing guidelines](contributing.md).**

To this:
- [ ] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**