### PR TITLE
Remove archived vue-cli-plugin-tauri

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 
 ### Integrations
 
-- [vue-cli-plugin-tauri](https://github.com/tauri-apps/vue-cli-plugin-tauri) ![officially maintained] - Turn your Vue SPA into a lightweight cross-platform desktop app.
 - [vite-plugin-tauri](https://github.com/amrbashir/vite-plugin-tauri) - Integrate Tauri in a Vite project to build cross-platform apps.
 - [axios-tauri-adapter](https://git.kaki87.net/KaKi87/axios-tauri-adapter) - `axios` adapter for the `@tauri-apps/api/http` module.
 - [svelte-tauri-filedrop](https://github.com/probablykasper/svelte-tauri-filedrop) - File drop handling component for Svelte.


### PR DESCRIPTION
### Plugins/Integrations

- [x] Works with **Tauri 1.x and onward**. -> Kinda broken.
- [x] The project is open source and accepts contributions. -> Nope.
- [x] The repo is at least 30 days old. -> It's archived longer than that.
- [x] Documentation is in English. -> Who needs documentation.
- [x] The project is active and maintained. -> Obviously not.

### Additional Context
