### PR TITLE
add leptos template

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-angular-template](https://github.com/charlesxsh/tauri-angular-boilerplate) - Angular template
 - [tauri-clojurescript-template](https://github.com/rome-user/tauri-clojurescript-template) - Minimal ClojureScript template with Shadow CLJS and React.
 - [tauri-deno-starter](https://github.com/marc2332/tauri-deno-starter) - React template using esbuild with Deno.
+- [tauri-leptos-template](https://gitlab.com/cristofa/tauri-leptos-template) - Leptos template
 - [tauri-nextjs-template](https://github.com/kvnxiao/tauri-nextjs-template) - Next.js (SSG) template, with TailwindCSS, opinionated linting, and GitHub Actions preconfigured.
 - [tauri-nuxt-template](https://github.com/HuakunShen/tauri-nuxt-template) - Nuxt3 template.
 - [tauri-preact-rsbuild-template](https://github.com/Alfredoes234/tauri-preact-rsbuild-template) - Preact template that uses rsbuild, rather than vite.


### PR DESCRIPTION
This is the link to the project: [tauri-leptos-tempalte](https://gitlab.com/cristofa/tauri-leptos-template)

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
- [x] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [x] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).

### Plugins/Integrations

<!-- Ignore unless you're contributing to Plugins/Integrations -->

- [ ] Works with **Tauri 1.x and onward**.
- [ ] The project is open source and accepts contributions.
- [ ] The repo is at least 30 days old.
- [ ] Documentation is in English.
- [ ] The project is active and maintained.

### Templates

<!-- Ignore unless you're contributing to Templates -->

- [ ] Works with **Tauri 1.x and onward**.
- [ ] The repo is at least 30 days old.
- [x] Documentation is in English.
- [x] The template provides enough information about how to get started and what's included.
- [x] The template is pretty different from the existing templates.

### Apps

<!-- Ignore unless you're contributing to Apps -->

- [ ] The app is original and not too simple.
- [ ] The README is in English.
- [ ] The app makes a reasonable effort to be fast, lightweight and secure.
- [ ] If the app closed source, evidence of it being built with Tauri is included.

### Additional Context


I've noticed Leptos template is missing and the one provided with create-tauri-app is very simple. I created a template showing how to properly use tauri commands with Leptos resources. I also included event example and tailwind css integration. All those things are not covered in any documentation I've seen. It's using Tauri 2.0  and it's not 30 days old though... Can it still be included? 

