### PR TITLE
Rename jarvis

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Testfully](https://testfully.io/) ![closed source] ![paid] - Offline API Client & Testing tool.
 - [verbcode](https://www.verbcode.com) ![closed source] ![paid] - Simplify your localization journey
 - [Yaak](https://yaak.app) ![closed source] - Interact with REST and GraphQL APIs
+- [DevClean](https://github.com/HuakunShen/devclean) - Clean up development environment with ease.
 
 ### Email & Feeds
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [claws](https://clawsapp.com/) ![closed source] - Visual interface for the AWS CLI.
 - [CrabNebula DevTools](https://crabnebula.dev/devtools) - Visual tool for understanding your app. Optimize the development process with easy debugging and profiling.
 - [DevBox](https://www.dev-box.app/) ![closed source] - Many useful tools for developers, like generators, viewers, converters, etc.
+- [DevClean](https://github.com/HuakunShen/devclean) - Clean up development environment with ease.
 - [DevTools-X](https://github.com/fosslife/devtools-x) - Collection of 30+ cross platform development utilities.
 - [Dropcode](https://github.com/egoist/dropcode) - Simple and lightweight code snippet manager.
 - [Echoo](https://github.com/zsmatrix62/echoo-app) - Offline/Online utilities for developers on MacOS & Windows.
@@ -183,9 +184,8 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [TableX](https://tablex-tan.vercel.app/) - Table viewer for modern developers
 - [Tauri Mobile Test](https://github.com/dedSyn4ps3/tauri-mobile-test) - Create and build cross-platform mobile applications.
 - [Testfully](https://testfully.io/) ![closed source] ![paid] - Offline API Client & Testing tool.
-- [verbcode](https://www.verbcode.com) ![closed source] ![paid] - Simplify your localization journey
-- [Yaak](https://yaak.app) ![closed source] - Interact with REST and GraphQL APIs
-- [DevClean](https://github.com/HuakunShen/devclean) - Clean up development environment with ease.
+- [verbcode](https://www.verbcode.com) ![closed source] ![paid] - Simplify your localization journey.
+- [Yaak](https://yaak.app) ![closed source] - Interact with REST and GraphQL APIs.
 
 ### Email & Feeds
 

--- a/README.md
+++ b/README.md
@@ -289,9 +289,9 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [GitBar](https://github.com/mikaelkristiansson/gitbar) - System tray app for GitHub reviews.
 - [Gitification](https://github.com/Gitification-App/gitification) - Menu bar app for managing Github notifications.
 - [Google Task Desktop Client](https://github.com/codad5/google-task-tauri) - Google Task Desktop Client
-- [Jarvis](https://jarvis.huakun.tech/) - Cross-platform, extensible app launcher. Alternative to Alfred and Raycast.
 - [Kanri](https://github.com/trobonox/kanri) - Cross-platform, offline-first Kanban board app with a focus on simplicity and user experience.
 - [Kianalol](https://github.com/zxh3/kianalol) - Spotlight-like efficiency tool for swift website access.
+- [Kunkun](https://kunkun.sh/) - Cross-platform, extensible app launcher. Alternative to Alfred and Raycast.
 - [Link Saas](https://github.com/linksaas/desktop) - Efficiency tools for software development teams.
 - [MacroGraph](https://github.com/Brendonovich/macrograph) - Visual programming for content creators.
 - [mynd](https://github.com/Gnarus-G/mynd) - Quick and very simple todo-list management app for developers that live mostly in the terminal.


### PR DESCRIPTION
This is just a project rename.

Rename `Jarvis` to `Kunkun`.

URl updated from `https://jarvis.huakun.tech` to `https://kunkun.sh`

A url redirection is configured to redirect old URL to new.