### PR TITLE
Removed Raspirus

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,6 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Gluhny](https://github.com/angeldollface/gluhny) A graphical interface to validate IMEI numbers.
 - [OneKeePass](https://github.com/OneKeePass/desktop) - Secure, modern, cross-platform and KeePass compatible password manager.
 - [Padloc](https://github.com/padloc/padloc) - Modern, open source password manager for individuals and teams.
-- [Raspirus](https://github.com/Raspirus/Raspirus) - User- and resources-friendly signatures-based malware scanner.
 - [Secops](https://github.com/kunalsin9h/secops) - Ubuntu Operating System security made easy.
 - [Tauthy](https://github.com/pwltr/tauthy) - Cross-platform TOTP authentication client.
 - [Truthy](https://github.com/fosslife/truthy/) - Modern cross-platform 2FA manager with tons of features and a beautiful UI.


### PR DESCRIPTION
I am the maintainer of the [Raspirus](https://github.com/Raspirus/Raspirus) app and we recently moved away from Tauri and are now fully written in Rust with the iced-rs GUI.

Thank you for having us on this page, but we no longer belong here so I removed the entry from the README