### PR TITLE
add tauri-plugin-pinia

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-plugin-fs-pro](https://github.com/ayangweb/tauri-plugin-fs-pro) - Extended with additional methods for files and directories.
 - [tauri-plugin-macos-permissions](https://github.com/ayangweb/tauri-plugin-macos-permissions) - Check and request macOS permissions to accessibility and full disk access.
 - [tauri-plugin-network](https://github.com/HuakunShen/tauri-plugin-network) - Tools for reading network information and scanning network.
+- [tauri-plugin-pinia](https://github.com/ferreira-tb/tauri-store/tree/main/packages/tauri-plugin-pinia) - Persistent Pinia stores for Tauri and Vue.
 - [tauri-plugin-prevent-default](https://github.com/ferreira-tb/tauri-plugin-prevent-default) - Disable default browser shortcuts.
 - [tauri-plugin-serialport](https://github.com/deid84/tauri-plugin-serialport) - Cross-compatible serialport communication tool.
 - [tauri-plugin-serialplugin](https://github.com/s00d/tauri-plugin-serialplugin) - Cross-compatible serialport communication tool for tauri 2.


### PR DESCRIPTION
This is the link to the project: [tauri-plugin-pinia](https://github.com/ferreira-tb/tauri-store/tree/main/packages/tauri-plugin-pinia)

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [ ] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
- [ ] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [ ] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [ ] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [x] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).

### Plugins/Integrations

<!-- Ignore unless you're contributing to Plugins/Integrations -->

- [ ] Works with **Tauri 1.x and onward**.
- [x] The project is open source and accepts contributions.
- [x] The repo is at least 30 days old.
- [x] Documentation is in English.
- [x] The project is active and maintained.


### Additional Context
This plugin is somewhat similar to the official store plugin but is designed specifically to support [Pinia](https://pinia.vuejs.org/) stores, leveraging Vue's reactivity system. It also includes additional features, such as watchers.

It depends on another crate [`tauri-store`](https://github.com/ferreira-tb/tauri-store), which could potentially serve as a foundation for supporting other frameworks as well (e.g. Svelte).