### PR TITLE
Update verbcode link

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [TableX](https://tablex-tan.vercel.app/) - Table viewer for modern developers
 - [Tauri Mobile Test](https://github.com/dedSyn4ps3/tauri-mobile-test) - Create and build cross-platform mobile applications.
 - [Testfully](https://testfully.io/) ![closed source] ![paid] - Offline API Client & Testing tool.
-- [verbcode](https://verbcode.staaph.com/) ![closed source] - Simplify your localization journey.
+- [verbcode]([https://verbcode.staaph.com/](https://github.com/Verbcode/verbcode-release)) ![closed source] - Simplify your localization journey.
 - [Worktree Status](https://github.com/sandercox/worktree-status/) - Get git repo status in your macOS MenuBar or Windows notification area.
 - [Yaak](https://yaak.app) - Organize and execute REST, GraphQL, and gRPC requests.
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [TableX](https://tablex-tan.vercel.app/) - Table viewer for modern developers
 - [Tauri Mobile Test](https://github.com/dedSyn4ps3/tauri-mobile-test) - Create and build cross-platform mobile applications.
 - [Testfully](https://testfully.io/) ![closed source] ![paid] - Offline API Client & Testing tool.
-- [verbcode]([https://verbcode.staaph.com/](https://github.com/Verbcode/verbcode-release)) ![closed source] - Simplify your localization journey.
+- [verbcode](https://github.com/Verbcode/verbcode-release) ![closed source] - Simplify your localization journey.
 - [Worktree Status](https://github.com/sandercox/worktree-status/) - Get git repo status in your macOS MenuBar or Windows notification area.
 - [Yaak](https://yaak.app) - Organize and execute REST, GraphQL, and gRPC requests.
 


### PR DESCRIPTION
The [website](https://verbcode.staaph.com) throws a 404. Linking to GitHub repo instead (binaries are in releases).