### PR TITLE
Add Shard Launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Retrom](https://github.com/JMBeresford/retrom) - Private cloud game library distribution server + frontend/launcher.
 - [Samira](https://github.com/jsnli/Samira) - Steam achievement manager for Linux.
 - [Sarge Launcher](https://github.com/endless-r0ad/sarge-launcher) ![v2] - Cross-platform launcher for Quake 3 Arena and Q3A mods - includes server, demo, and level browsing.
+- [Shard Launcher](https://github.com/Th0rgal/shard) ![v2] - Open-source Minecraft launcher with declarative profiles, content-addressed storage, and Modrinth/CurseForge integration.
 - [SJMC Launcher](https://github.com/UNIkeEN/SJMCL) ![v2] - Launcher for `Minecraft` with instance management and multi-account support.
 - [Steam Art Manager](https://github.com/Tormak9970/Steam-Art-Manager) - Tool for customizing the art of your Steam games.
 - [Tauri Chess](https://github.com/jamessizeland/tauri-chess) - Implementation of Chess, logic in Rust and visualization in React.


### PR DESCRIPTION
Added Shard Launcher to the Gaming section in alphabetical order.

Shard is an open-source Minecraft launcher built with Tauri 2. It features declarative JSON profiles, content-addressed storage for deduplication, and Modrinth/CurseForge integration.

Source: https://github.com/Th0rgal/shard

Thank you for maintaining this list.