### PR TITLE
Add tauri-plugin-velesdb to Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-plugin-tcp](https://github.com/kuyoonjo/tauri-plugin-tcp) - TCP socket support.
 - [tauri-plugin-theme](https://github.com/wyhaya/tauri-plugin-theme) - Dynamically change Tauri App theme.
 - [tauri-plugin-udp](https://github.com/kuyoonjo/tauri-plugin-udp) - UDP socket support.
+- [tauri-plugin-velesdb](https://github.com/cyberlife-coder/VelesDB) - Native vector database plugin. 70µs semantic search, ≥95% recall, hybrid BM25+vector, offline-first, full ecosystem integrations and more.
 - [tauri-plugin-view](https://github.com/ecmel/tauri-plugin-view) - View and share files on mobile.
 - [tauri-remote-ui](https://github.com/DraviaVemal/tauri-remote-ui) - Make you web app bundle available as web page for test and development.
 - [taurpc](https://github.com/MatsDK/TauRPC) - Typesafe IPC wrapper for Tauri commands and events.


### PR DESCRIPTION
# Pull Request: Add tauri-plugin-velesdb to the list

## Title
Add tauri-plugin-velesdb to Plugins section

## Description

Hello! I would like to add `tauri-plugin-velesdb` to the Plugins section.

**tauri-plugin-velesdb** is a native Tauri plugin for embedded vector search in desktop applications.

### Key features

- Embedded vector database (no external server)
- HNSW index with SIMD acceleration
- Hybrid BM25 + vector search
- Offline-first, works without internet

### Installation

```toml
# src-tauri/Cargo.toml
[dependencies]
tauri-plugin-velesdb = "1.1"
```

```bash
# Frontend
npm install @wiscale/tauri-plugin-velesdb
```

### Usage

```rust
// Rust - Plugin registration
fn main() {
    tauri::Builder::default()
        .plugin(tauri_plugin_velesdb::init("./data"))
        .run(tauri::generate_context!())
        .expect("error while running tauri application");
}
```

```javascript
// JavaScript - Frontend API
import { invoke } from '@tauri-apps/api/core';

await invoke('plugin:velesdb|create_collection', {
    request: { name: 'documents', dimension: 768, metric: 'cosine' }
});

const results = await invoke('plugin:velesdb|search', {
    request: { collection: 'documents', vector: [...], topK: 10 }
});
```

Documentation: https://deepwiki.com/cyberlife-coder/VelesDB

I have placed it in alphabetical order.

Thanks for maintaining this list!
