### PR TITLE
Add Kunobi

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Keadex Mina](https://github.com/keadex/keadex) - Open Source, serverless IDE to easily code and organize at a scale C4 model diagrams.
 - [Keyring Demo](https://github.com/open-source-cooperative/keyring-rs/wiki/Keyring) ![v2] - GUI for the Rust `keyring` ecosystem
 - [KFtray](https://github.com/hcavarsan/kftray) - A tray application that manages port forwarding in Kubernetes.
+- [Kunobi](https://kunobi.ninja) ![closed source] - Rust Kubernetes management from your desktop, with built-in MCP server.
 - [PraccJS](https://github.com/alyalin/PraccJS) - Lets you practice JavaScript with real-time code execution.
 - [PromptLab](https://github.com/haideralsh/prompt-lab) ![v2] - Open-source, cross-platform desktop app for building and providing code-related context to large language models
 - [nda](https://github.com/kuyoonjo/nda) - Network Debug Assistant - UDP, TCP, Websocket, SocketIO, MQTT


### PR DESCRIPTION
Add [Kunobi](https://kunobi.ninja) to the Developer tools section.

Kunobi is a Rust Kubernetes management desktop app built with Tauri, with built-in MCP server.