### PR TITLE
Add Beadbox to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [AppCenter Companion](https://github.com/zenoxs/tauri-appcenter-companion) - Regroup, build and track your `VS App Center` apps.
 - [AppHub](https://github.com/francesco-gaglione/AppHub) - Streamlines .appImage package installation, management, and uninstallation through an intuitive Linux desktop interface.
 - [Aptakube](https://aptakube.com/) ![closed source] - Multi-cluster Kubernetes UI.
+- [Beadbox](https://beadbox.app) ![closed source] ![v2] - Real-time visual dashboard for AI agent workflows, built on the [beads](https://github.com/steveyegge/beads) issue tracker.
 - [Brew Services Manage](https://github.com/persiliao/brew-services-manage)![closed source] macOS Menu Bar application for managing Homebrew services.
 - [claws](https://clawsapp.com/) ![closed source] - Visual interface for the AWS CLI.
 - [CrabNebula DevTools](https://crabnebula.dev/devtools) - Visual tool for understanding your app. Optimize the development process with easy debugging and profiling.


### PR DESCRIPTION
Adds [Beadbox](https://beadbox.app) to the Developer Tools section.

Beadbox is a real-time visual dashboard for AI agent workflows, built on the [beads](https://github.com/steveyegge/beads) issue tracker. It uses Tauri v2 with a Next.js frontend and runs on macOS and Linux.

- Website: https://beadbox.app
- GitHub: https://github.com/beadbox/beadbox