### PR TITLE
Add Stik - Quick capture note app with on-device AI search

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Remind Me Again](https://github.com/probablykasper/remind-me-again) - Toggleable reminders app for Mac, Linux and Windows.
 - [Runtime](https://github.com/runtime-org/runtime) ![v2] - AI taskmate for web & office tools.
 - [Shell360](https://github.com/nashaofu/shell360) ![v2] - Cross-platform open-source SSH and SFTP client with port forwarding and encrypted data storage, designed for developers and system administrators.
+- [Stik](https://github.com/0xMassi/stik_app) ![v2] - Instant thought capture for macOS with on-device AI semantic search. Hotkey → type → done. 8MB binary, plain markdown files, MIT licensed.
 - [Takma](https://github.com/jam53/Takma) - Kanban-style to-do app, fully offline with support for Markdown, labels, due dates, checklists and deep linking.
 - [Tencent Yuanbao](https://yuanbao.tencent.com/) ![closed source] - Tencent Yuanbao is an AI application based on Tencent Hunyuan large model. It is an all-round assistant that can help you with writing, painting, copywriting, translation, programming, searching, reading and summarizing.
 - [TimeChunks](https://danielulrich.com/en/timechunks/) ![closed source] - Time tracking for freelancers without timers and HH:MM:SS inputs.


### PR DESCRIPTION
**Stik** is a quick-capture note app for macOS built with Tauri 2.0 (Rust + React 19 + TypeScript).

### Why it fits awesome-tauri

- **Tauri 2.0** — 8MB binary, ~20MB RAM usage
- **Swift sidecar** — Uses Apple's NaturalLanguage framework for on-device semantic search via a Swift CLI sidecar, which is an interesting Tauri pattern for accessing native Apple frameworks
- **Local-first** — All notes stored as plain `.md` files, all AI runs on-device
- **MIT licensed** — Fully open source

### Key features

- Global hotkey to summon floating capture window
- Hybrid search (text + vector similarity) with language-aware embeddings
- AI-powered folder suggestions
- Wiki-links, vim mode, folder-scoped search
- Pin notes as floating sticky notes
- Git-based folder sharing

### Links

- GitHub: https://github.com/0xMassi/stik_app
- Website: https://stik.ink
- Homebrew: `brew install --cask stik`

### Traction

- 600+ downloads in first week
- ~100 GitHub stars
- 4 releases in 7 days