### PR TITLE
Add Yume - Desktop GUI for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [verbcode](https://github.com/Verbcode/verbcode-release) ![closed source] - Simplify your localization journey.
 - [Worktree Status](https://github.com/sandercox/worktree-status/) - Get git repo status in your macOS MenuBar or Windows notification area.
 - [Yaak](https://yaak.app) - Organize and execute REST, GraphQL, and gRPC requests.
+- [Yume](https://github.com/aofp/yume) ![v2] - Native desktop GUI for Claude Code with multi-tab sessions, background agents, context compaction, and plugin system.
 
 ### Ebook readers
 


### PR DESCRIPTION
## Description

Add [Yume](https://github.com/aofp/yume) to the **Developer tools** section.

Yume is a native desktop GUI for Claude Code built with Tauri 2.x, React 19, and Rust. It provides multi-tab sessions, background agents, context compaction, a plugin system, and more.

- **Section:** Developer tools (alphabetical placement after Yaak)
- **Badge:** `![v2]` (Tauri 2.x)
- **Source:** https://github.com/aofp/yume