### PR TITLE
Add Brood to Applications > Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Aptakube](https://aptakube.com/) ![closed source] - Multi-cluster Kubernetes UI.
 - [Beadbox](https://beadbox.app) ![closed source] - Real-time visual dashboard for monitoring AI agent task coordination, dependencies, and handoffs.
 - [Brew Services Manage](https://github.com/persiliao/brew-services-manage)![closed source] macOS Menu Bar application for managing Homebrew services.
+- [Brood](https://github.com/kevinshowkat/brood) ![v2] - Reference-first AI image editing desktop app for developers.
 - [claws](https://clawsapp.com/) ![closed source] - Visual interface for the AWS CLI.
 - [CrabNebula DevTools](https://crabnebula.dev/devtools) - Visual tool for understanding your app. Optimize the development process with easy debugging and profiling.
 - [CrabNebula DevTools Premium](https://crabnebula.dev/devtools) ![closed source] ![paid] - Optimize the development process with easy debugging and profiling. Debug the Rust portion of your app with the same comfort as JavaScript!


### PR DESCRIPTION
Adds Brood (https://github.com/kevinshowkat/brood) to the **Applications > Developer tools** section.\n\n- Tauri v2 app\n- Entry is alphabetically placed\n- Description kept concise per list style