### PR TITLE
Add tauri-plugin-audio-recorder to Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-plugin-android-battery-optimization](https://github.com/NeoHuncho/tauri-plugin-android-battery-optimization) - Check and request battery optimization exemptions on Android.
 - [tauri-plugin-android-fs](https://github.com/aiueo13/tauri-plugin-android-fs) ![v2] - Access the file system on Android.
 - [tauri-plugin-aptabase](https://github.com/aptabase/tauri-plugin-aptabase) - Privacy-first and minimalist analytics for desktop and mobile apps.
+- [tauri-plugin-audio-recorder](https://github.com/brenogonzaga/tauri-plugin-audio-recorder) ![v2] - Cross-platform audio recording with pause/resume, quality presets, and real-time duration monitoring.
 - [tauri-plugin-auth](https://github.com/inKibra/tauri-plugins/tree/main/packages/tauri-plugin-auth) - Auth plugin for iOS that uses ASWebAuthenticationSession for authentication, which allows keychain access
 - [tauri-plugin-blec](https://github.com/MnlPhlp/tauri-plugin-blec) - Cross platform Bluetooth Low Energy client based on `btleplug`.
 - [tauri-plugin-cache](https://github.com/Taiizor/tauri-plugin-cache) - Advanced disk caching solution with memory layer, TTL management, compression support, and cross-platform compatibility for desktop and mobile.


### PR DESCRIPTION
# Description
Add [tauri-plugin-audio-recorder](https://github.com/brenogonzaga/tauri-plugin-audio-recorder) to the Plugins section.

## Plugin Description
Cross-platform audio recording plugin for Tauri 2.x applications with pause/resume, quality presets, and real-time duration monitoring for desktop (Windows, macOS, Linux) and mobile (iOS, Android).

## Checklist
- [x] Works with **Tauri 2.x or later**
- [x] The project is open source and accepts contributions
- [x] The repo is at least 30 days old
- [x] Documentation is in English
- [x] The project is active and maintained
- [x] Description does not start with `A` or `An`
- [x] Description is under 24 words
- [x] Entries are alphabetically ordered