### PR TITLE
Add tauri-plugin-media-toolkit to Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-plugin-js](https://github.com/HuakunShen/tauri-plugin-js) ![v2] - Give your app Electron-like JS backends with type-safe RPC powered by `kkrpc`. Supports Bun, Node.js, and Deno.
 - [tauri-plugin-keep-screen-on](https://gitlab.com/cristofa/tauri-plugin-keep-screen-on) - Disable screen timeout on Android and iOS.
 - [tauri-plugin-macos-permissions](https://github.com/ayangweb/tauri-plugin-macos-permissions) - Support for checking and requesting macOS system permissions.
+- [tauri-plugin-media-toolkit](https://github.com/brenogonzaga/tauri-plugin-media-toolkit) ![v2] - Media editing, playback, and analysis with trim, convert, extract audio, and quality presets.
 - [tauri-plugin-mobile-sharetarget](https://github.com/IT-ess/tauri-plugin-mobile-sharetarget) ![v2] - Handle mobile Share Intents with a FIFO queue
 - [tauri-plugin-mqtt](https://github.com/kuyoonjo/tauri-plugin-mqtt) - MQTT client support.
 - [tauri-plugin-network](https://github.com/HuakunShen/tauri-plugin-network) - Tools for reading network information and scanning network.


### PR DESCRIPTION
# Description
Add [tauri-plugin-media-toolkit](https://github.com/brenogonzaga/tauri-plugin-media-toolkit) to the Plugins section.

## Plugin Description
Cross-platform media toolkit plugin for Tauri 2.x applications with media editing, playback, and analysis capabilities (trim, convert, extract audio) for desktop (Windows, macOS, Linux) and mobile (iOS, Android).

## Checklist
- [x] Works with **Tauri 2.x or later**
- [x] The project is open source and accepts contributions
- [x] The repo is at least 30 days old
- [x] Documentation is in English
- [x] The project is active and maintained
- [x] Description does not start with `A` or `An`
- [x] Description is under 24 words
- [x] Entries are alphabetically ordered
