### PR TITLE
Add tauri-plugin-stt to Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-plugin-serialport](https://github.com/deid84/tauri-plugin-serialport) - Cross-compatible serialport communication tool.
 - [tauri-plugin-serialplugin](https://github.com/s00d/tauri-plugin-serialplugin) - Cross-compatible serialport communication tool for tauri 2.
 - [tauri-plugin-sharesheet](https://github.com/buildyourwebapp/tauri-plugin-sharesheet) - Share content to other apps via the Android Sharesheet or iOS Share Pane.
+- [tauri-plugin-stt](https://github.com/brenogonzaga/tauri-plugin-stt) ![v2] - Real-time speech-to-text recognition with multi-language support for desktop and mobile.
 - [tauri-plugin-svelte](https://github.com/ferreira-tb/tauri-store/tree/main/packages/plugin-svelte) - Persistent Svelte stores.
 - [tauri-plugin-system-info](https://github.com/HuakunShen/tauri-plugin-system-info) - Detailed system information.
 - [tauri-plugin-tcp](https://github.com/kuyoonjo/tauri-plugin-tcp) - TCP socket support.


### PR DESCRIPTION
# Description
Add [tauri-plugin-stt](https://github.com/brenogonzaga/tauri-plugin-stt) to the Plugins section.

## Plugin Description
Cross-platform speech-to-text recognition plugin for Tauri 2.x applications with real-time transcription, multi-language support, and interim results for desktop (Windows, macOS, Linux) and mobile (iOS, Android).

## Checklist
- [x] Works with **Tauri 2.x or later**
- [x] The project is open source and accepts contributions
- [x] The repo is at least 30 days old
- [x] Documentation is in English
- [x] The project is active and maintained
- [x] Description does not start with `A` or `An`
- [x] Description is under 24 words
- [x] Entries are alphabetically ordered
