### PR TITLE
Add c9watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Aptakube](https://aptakube.com/) ![closed source] - Multi-cluster Kubernetes UI.
 - [Beadbox](https://beadbox.app) ![closed source] - Real-time visual dashboard for monitoring AI agent task coordination, dependencies, and handoffs.
 - [Brew Services Manage](https://github.com/persiliao/brew-services-manage)![closed source] macOS Menu Bar application for managing Homebrew services.
+- [c9watch](https://github.com/minchenlee/c9watch) - macOS menu bar app that monitors all running Claude Code sessions in real-time.
 - [claws](https://clawsapp.com/) ![closed source] - Visual interface for the AWS CLI.
 - [CrabNebula DevTools](https://crabnebula.dev/devtools) - Visual tool for understanding your app. Optimize the development process with easy debugging and profiling.
 - [CrabNebula DevTools Premium](https://crabnebula.dev/devtools) ![closed source] ![paid] - Optimize the development process with easy debugging and profiling. Debug the Rust portion of your app with the same comfort as JavaScript!


### PR DESCRIPTION
Adding c9watch to the Developer tools section.

- [x] The entry is in the correct format: `[Title](link) - Description.`
- [x] Added alphabetically (between `claws` and `CrabNebula DevTools`)
- [x] Description is under 24 words and does not start with A or An
- [x] No trailing whitespace
- [x] One suggestion per pull request
- [x] App is original and not too simple
- [x] README is in English
- [x] Built with Tauri 2.x (Rust + Svelte 5)
- [x] Makes reasonable effort to be fast and lightweight (Rust backend, no Electron)