### PR TITLE
Add AFK to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 
 ### Productivity
 
+- [AFK](https://github.com/Harry-kp/afk) - Lightweight break reminder following the 20-20-20 rule with fullscreen reminders, statistics dashboard, and health exercises.
 - [Banban](https://github.com/HubertK05/banban) - Kanban board with tags, categories and markdown support.
 - [Blink Eye](https://github.com/nomandhoni-cs/blink-eye) - A minimalist eye care reminder app to reduce eye strain, featuring customizable timers , full-screen popups, and screen-on-time.
 - [BuildLog](https://github.com/rajatkulkarni95/buildlog) - Menu bar for keeping track of Vercel Deployments.


### PR DESCRIPTION
## Add AFK

[AFK](https://github.com/Harry-kp/afk) is a lightweight break reminder built with Tauri that follows the 20-20-20 rule. It lives in the menu bar and shows fullscreen break reminders with health exercises.

**Key features:** Configurable timing, statistics dashboard, global keyboard shortcuts, health exercises during breaks, < 5 MB app size.

- [Website](https://afk-app.vercel.app)
- [GitHub](https://github.com/Harry-kp/afk)
- License: MIT
- Section: Productivity