### PR TITLE
Add Notemac++ to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [MeadTools](https://github.com/ljreaux/meadtools-desktop) - All-in-one Mead, Wine, and Cider making calculator.
 - [Mind Elixir Desktop](https://desktop.mind-elixir.com) ![closed source] ![paid] - AI-powered mind mapping that keeps your ideas organized.
 - [mynd](https://github.com/Gnarus-G/mynd) - Quick and very simple todo-list management app for developers that live mostly in the terminal.
+- [Notemac++](https://github.com/sergioadevita/notemac-plus-plus) - A Notepad++-inspired code editor for macOS and web with 70+ language support, Git integration, AI coding assistant, and integrated terminal.
 - [Obliqoro](https://github.com/mrjackwills/obliqoro) - Oblique Strategies meets Pomodoro.
 - [PasteBar](https://github.com/PasteBar/PasteBarApp) - Limitless, Free Clipboard Manager for Mac and Windows. Effortless management of everything you copy and paste.
 - [PicSharp](https://github.com/AkiraBit/PicSharp) ![v2] - With powerful and richly configured compression functions, it helps you easily optimize images, providing outstanding performance and a convenient operation experience.


### PR DESCRIPTION
Notemac++ is a Notepad++-inspired code editor built with Tauri v2 + React + Monaco Editor. Features include 70+ language syntax highlighting, built-in Git integration, AI coding assistant, integrated terminal, macros, bookmarks, split views, and 7 themes. MIT licensed.

This is the link to the project: [Notemac++](https://github.com/sergioadevita/notemac-plus-plus)

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
- [x] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v1** add the `![v1]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v2** add the `![v2]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.

### Applications

- [x] Works with **Tauri 2.x or later**.
- [x] The project is open source and accepts contributions.
- [x] The repo is at least 30 days old.
- [x] Documentation is in English.
- [x] The project is active and maintained.
- [x] The project has at least 20 stars.