### PR TITLE
Add Lyra Music to Audio & Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Hypetrigger](https://hypetrigger.io/) ![closed source] - Detect highlight clips in video with FFMPEG + Tensorflow on the GPU.
 - [Char](https://github.com/fastrepl/char) - AI notepad for meetings with flexible AI stack and on-device storage.
 - [Jellyfin Vue](https://github.com/jellyfin/jellyfin-vue) - GUI client for a Jellyfin server based on Vue.js and Tauri.
+- [Lyra Music](https://github.com/twtrubiks/lyra-music) ![v2] - Lightweight Linux desktop music player built with Svelte 5 and rodio for pure-Rust audio playback.
 - [Lofi Engine](https://github.com/meel-hd/lofi-engine) - Generate Lo-Fi music on the go and locally.
 - [mediarepo](https://github.com/Trivernis/mediarepo) - Tag-based media management application.
 - [Mr Tagger](https://github.com/probablykasper/mr-tagger) - Music file tagging app.


### PR DESCRIPTION
Add [Lyra Music](https://github.com/twtrubiks/lyra-music) to the Audio & Video section.

Lyra Music is a lightweight Linux desktop music player built with **Tauri 2** and **Svelte 5**. It uses **rodio** for pure-Rust audio playback (no FFmpeg/GStreamer dependency) and stores data in **SQLite** (WAL mode).