### PR TITLE
Add ClawPier to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Beadbox](https://beadbox.app) ![closed source] - Real-time visual dashboard for monitoring AI agent task coordination, dependencies, and handoffs.
 - [Brew Services Manage](https://github.com/persiliao/brew-services-manage)![closed source] macOS Menu Bar application for managing Homebrew services.
 - [claws](https://clawsapp.com/) ![closed source] - Visual interface for the AWS CLI.
+- [ClawPier](https://github.com/SebastianElvis/clawpier) ![v2] - Native desktop app for managing sandboxed OpenClaw AI agent instances via Docker, with skill browser, live monitoring, and interactive terminal.
 - [CrabNebula DevTools](https://crabnebula.dev/devtools) - Visual tool for understanding your app. Optimize the development process with easy debugging and profiling.
 - [CrabNebula DevTools Premium](https://crabnebula.dev/devtools) ![closed source] ![paid] - Optimize the development process with easy debugging and profiling. Debug the Rust portion of your app with the same comfort as JavaScript!
 - [DevBox](https://www.dev-box.app/) ![closed source] - Many useful tools for developers, like generators, viewers, converters, etc.


### PR DESCRIPTION
## What is ClawPier?

[ClawPier](https://github.com/SebastianElvis/clawpier) is a native desktop app for managing sandboxed [OpenClaw](https://github.com/openclaw) AI agent instances via Docker.

Built with **Tauri v2** (Rust + React). macOS builds are code-signed and notarized.

### Key features

- Sandboxed by default — containers start with `--network none`
- ClawHub skill browser — browse 50+ bundled skills, search & install from registry
- Interactive terminal, live logs, file browser, resource monitoring
- Port mapping presets with conflict detection
- Health checks with auto-restart
- Dark mode, keyboard shortcuts, status notifications

### Links

- **GitHub:** https://github.com/SebastianElvis/clawpier
- **Install:** `brew tap SebastianElvis/clawpier && brew install --cask clawpier`
- **Platforms:** macOS (signed & notarized), Linux, Windows