### PR TITLE
Add TransEcho to Audio & Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Screenpipe](https://github.com/mediar-ai/screenpipe) - 24/7 local AI screen & mic recording. Build AI apps with full context. Works with Ollama.
 - [SilentKeys](https://github.com/gptguy/silentkeys) ![v2] - Privacy-first, real-time dictation app built with Tauri, powered by `Parakeet ASR`, `Silero-VAD`, and on-device inference via `ORT`.
 - [ToneTempo](https://tonetempo.com) ![closed source] ![paid] - Workout and run with AutoMixed music and an AI fitness coach.
+- [TransEcho](https://github.com/wxkingstar/TransEcho) ![v2] - Real-time simultaneous interpretation app that captures system audio and translates with subtitles + TTS voice output. Supports 8 languages.
 - [Voxly](https://github.com/ibrahimshadev/dikt) ![v2] - Voice dictation app with AI modes that clean up speech before pasting into any active app.
 - [Watson.ai](https://github.com/LatentDream/watson.ai) - Easily record and extract the most important information from your meetings.
 - [Whispering](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![v2] - Speech-to-text app. Press shortcut → speak → get text. Supports local and cloud transcription with AI transformations.


### PR DESCRIPTION
Adding [TransEcho](https://github.com/wxkingstar/TransEcho), a real-time simultaneous interpretation desktop app built with Tauri 2 + Rust + Svelte 5.

It captures system audio (ScreenCaptureKit on macOS, WASAPI on Windows) and translates it in real-time with subtitles and optional TTS voice output. Supports 8 languages.

MIT licensed, open source.