### PR TITLE
Add Locally Uncensored to ChatGPT clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [ChatGPT-Desktop](https://github.com/Synaptrix/ChatGPT-Desktop) - Cross-platform productivity ChatGPT assistant launcher.
 - [Jan](https://github.com/menloresearch/jan) ![v2] - Open source alternative to ChatGPT that runs 100% offline on your computer.
 - [Kaas](https://github.com/0xfrankz/Kaas) - Cross-platform desktop LLM client for OpenAI ChatGPT, Anthropic Claude, Microsoft Azure and more, with a focus on privacy and security.
+- [Locally Uncensored](https://github.com/PurpleDoubleD/locally-uncensored) - All-in-one local AI app for uncensored chat, image generation, and video creation using Ollama and ComfyUI.
 - [Nexo](https://github.com/Nexo-Agent/nexo) - All-in-One Workspace AI
 - [Orion](https://github.com/taecontrol/orion) - Cross-platform app that lets you create multiple AI assistants with specific goals powered with ChatGPT.
 - [Oxide-Lab](https://github.com/FerrisMind/oxide-lab) ![v2] - Local LLM chat application with privacy-focused AI inference using `candle` and Rust backend.


### PR DESCRIPTION
Adds **Locally Uncensored** to the ChatGPT clients section.

Locally Uncensored is a free, open-source (MIT) desktop app built with Tauri for uncensored local AI chat, image generation, and video creation using Ollama and ComfyUI. All inference runs locally.

- GitHub: https://github.com/PurpleDoubleD/locally-uncensored
- Stack: React, TypeScript, Tauri v2, Ollama, ComfyUI
- License: MIT