### PR TITLE
Add ClawBox - sandboxed AI agent desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 
 - [ChatGPT](https://github.com/lencx/ChatGPT) - Cross-platform ChatGPT desktop application.
 - [ChatGPT-Desktop](https://github.com/Synaptrix/ChatGPT-Desktop) - Cross-platform productivity ChatGPT assistant launcher.
+- [ClawBox](https://github.com/coderkk1992/clawbox) ![v2] - Run OpenClaw AI agent in a sandboxed Linux VM with a native macOS interface.
 - [Jan](https://github.com/menloresearch/jan) ![v2] - Open source alternative to ChatGPT that runs 100% offline on your computer.
 - [Kaas](https://github.com/0xfrankz/Kaas) - Cross-platform desktop LLM client for OpenAI ChatGPT, Anthropic Claude, Microsoft Azure and more, with a focus on privacy and security.
 - [Nexo](https://github.com/Nexo-Agent/nexo) - All-in-One Workspace AI


### PR DESCRIPTION
## Description

Adding [ClawBox](https://github.com/coderkk1992/clawbox) to the ChatGPT clients section.

ClawBox is a Tauri 2.0 desktop app that wraps OpenClaw (an AI agent) in a sandboxed Linux VM, providing:

- Native macOS interface for AI interactions
- Isolated VM environment (via Lima) so the AI can't access your host system
- Support for Claude and GPT models
- Drag & drop file sharing with the AI
- Multi-agent support

Built with Tauri 2.0 + React + TypeScript.

## Checklist

- [x] Project is open source
- [x] Project uses Tauri 2.0
- [x] Added to appropriate category (ChatGPT clients)
- [x] Entry follows existing format