### PR TITLE
Add Typer - free local AI chat for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Orion](https://github.com/taecontrol/orion) - Cross-platform app that lets you create multiple AI assistants with specific goals powered with ChatGPT.
 - [Oxide-Lab](https://github.com/FerrisMind/oxide-lab) ![v2] - Local LLM chat application with privacy-focused AI inference using `candle` and Rust backend.
 - [QuickGPT](https://github.com/dubisdev/quickgpt) - Lightweight AI assistant for Windows.
+- [Typer](https://typer.space) ![closed source] - Free local AI chat for macOS. Runs entirely on-device with no account, no cloud, and no ads. Apple Silicon required.
 - [Yack](https://github.com/rajatkulkarni95/yack) - Spotlight like app for interfacing with GPT APIs.
 
 ### Data

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Orion](https://github.com/taecontrol/orion) - Cross-platform app that lets you create multiple AI assistants with specific goals powered with ChatGPT.
 - [Oxide-Lab](https://github.com/FerrisMind/oxide-lab) ![v2] - Local LLM chat application with privacy-focused AI inference using `candle` and Rust backend.
 - [QuickGPT](https://github.com/dubisdev/quickgpt) - Lightweight AI assistant for Windows.
-- [Typer](https://typer.space) ![closed source] - Free local AI chat for macOS. Runs entirely on-device with no account, no cloud, and no ads. Apple Silicon required.
+- [Typer](https://typer.space) ![closed source] ![v2] - Free local AI chat for macOS. Runs entirely on-device with no account, no cloud, and no ads. Apple Silicon required.
 - [Yack](https://github.com/rajatkulkarni95/yack) - Spotlight like app for interfacing with GPT APIs.
 
 ### Data


### PR DESCRIPTION
This is the link to the project: [Typer](https://typer.space)

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`. ✓ (already added)
- [ ] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`. (N/A — Typer is free)
- [ ] If the project/article uses Tauri **v1** add the `![v1]` badge after the `(link)` but before the `-`. (N/A — Typer uses v2)
- [x] If the project/article uses Tauri **v2** add the `![v2]` badge after the `(link)` but before the `-`. (note: Typer uses Tauri v2, so the `![v2]` badge should be added — see below)
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.

### Apps

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure.
- [x] If the app is closed source, evidence of it being built with Tauri is included. (Typer is built with Tauri + Rust; the app is distributed via the Mac App Store at https://apps.apple.com/app/typer-ai/id6751274483)

### Additional Context

Typer is a free, closed-source local AI chat app for macOS (Apple Silicon), built with Tauri + Rust + Metal. It runs AI models entirely on-device — no account, no cloud, no ads, works offline. It fits the ChatGPT clients section alongside other local AI apps like Jan and Oxide-Lab.

App Store: https://apps.apple.com/app/typer-ai/id6751274483