### PR TITLE
Add SoloMD - Lightweight Markdown editor built with Tauri 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Notpad](https://github.com/Muhammed-Rahif/Notpad) - Cross-platform rich text editor with a notepad interface, enhanced with advanced features beyond standard notepad.
 - [Parchment](https://github.com/tywil04/parchment) - Simple local-only cross-platform text editor with basic markdown support.
 - [Semanmeter](https://yibiao.fun/) ![closed source] - OCR and document conversion software.
+- [SoloMD](https://github.com/zhitongblog/solomd) ![v2] - Lightweight (~15 MB) Markdown editor with live preview, KaTeX math, and Mermaid diagrams. Zero telemetry.
 - [Ubiquity](https://github.com/opensourcecheemsburgers/ubiquity) - Cross-platform markdown editor; built with Yew, Tailwind, and DaisyUI.
 - [HuLa](https://github.com/HuLaSpark/HuLa) - HuLa is a desktop instant messaging app built on Tauri+Vue3 (not just instant messaging).
 - [Gramax](https://github.com/Gram-ax/gramax) - Free, open-source application for creating, editing, and publishing Git-driven documentation sites using Markdown and a visual editor.


### PR DESCRIPTION
## What is SoloMD?

SoloMD is a lightweight, cross-platform Markdown editor (~15 MB installed) built with Tauri 2, Vue 3, and CodeMirror 6.

**Key features:**
- Live preview (Markdown markers hide when cursor leaves the line)
- KaTeX math rendering
- Mermaid diagrams
- Multi-encoding support (UTF-8, GBK, Big5, Shift_JIS)
- Zero telemetry, fully offline
- Export to HTML/PDF/DOCX

**Links:**
- Website: https://solomd.app
- GitHub: https://github.com/zhitongblog/solomd
- License: MIT

**Platforms:** macOS (universal), Windows (x64), Linux (AppImage/deb/rpm)

This is a real-world Tauri 2 application that might be useful for developers exploring the framework.