### PR TITLE
Add FreeFile ITR to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Compotes](https://github.com/Orbitale/Compotes) - Local bank account operations storage to vizualize them as graphs and customize them with rules and tags for better filtering.
 - [CryptoBal](https://github.com/Rabbit-Company/CryptoBal-Desktop) - Desktop application for monitoring your crypto assets.
 - [Fincept Terminal](https://github.com/Fincept-Corporation/FinceptTerminal) ![v2] - Advanced financial intelligence terminal with CFA-level analytics, AI agents, and 100+ data connectors.
+- [FreeFile ITR](https://github.com/rohitthink/freefile) ![v2] - Free, privacy-first income tax return filing app for Indian freelancers. Imports bank statements, computes tax under both regimes, and files directly on the official income tax portal. All data stored locally.
 - [Ghorbu Wallet](https://github.com/matthias-wright/ghorbu-wallet) - Cross-platform desktop HD wallet for Bitcoin.
 - [Mahalli](https://github.com/AbdelilahOu/Mahalli-tauri) - Local first inventory and invoicing management app.
 - [nym-wallet](https://github.com/nymtech/nym/tree/develop/nym-wallet) - The Nym desktop wallet enables you to use the Nym network and take advantage of its key capabilities.


### PR DESCRIPTION
Adding **FreeFile ITR** — a privacy-first income tax return filing app for Indian freelancers built with Tauri 2.

**Project:** https://github.com/rohitthink/freefile
**License:** AGPL-3.0
**Tauri version:** v2

## What it is

FreeFile is a local-first desktop (and mobile) tax filing app for Indian freelancers and consultants. It imports bank statements from the five largest Indian banks, auto-categorizes transactions, computes tax under both old and new regimes, and can file returns directly on the official incometax.gov.in portal via embedded browser automation.

## Why it belongs in Finance

- Personal finance: income tracking, expense categorization, tax computation
- Privacy-first: all financial data stored locally in SQLite, no telemetry
- Built with Tauri 2 + Next.js + FastAPI sidecar (Python backend bundled via PyInstaller)
- Actively maintained with community contribution infrastructure

Added in alphabetical order between "Fincept Terminal" and "Ghorbu Wallet".

Thanks for maintaining this list!