### PR TITLE
Add GitSquid to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Dropcode](https://github.com/egoist/dropcode) - Simple and lightweight code snippet manager.
 - [Echoo](https://github.com/zsmatrix62/echoo-app) - Offline/Online utilities for developers on MacOS & Windows.
 - [GitButler](https://gitbutler.com) - GitButler is a new Source Code Management system.
+- [GitSquid](https://gitsquid.dev) ![closed source] ![v2] - Cross-platform Git GUI client with visual commit graph, per-line staging and 10 languages.
 - [Github Security Alerts](https://github.com/stephanebouget/github-security-alerts) ![v2] - Monitors security vulnerabilities across your GitHub repositories in real-time.
 - [GitLight](https://github.com/colinlienard/gitlight) - GitHub & GitLab notifications on your desktop.
 - [JET Pilot](https://www.jet-pilot.app) - Kubernetes desktop client that focuses on less clutter, speed and good looks.


### PR DESCRIPTION
## Add GitSquid to Developer tools

[GitSquid](https://gitsquid.dev) is a cross-platform Git GUI client built with Tauri 2.x and Rust.

### Checklist

- [x] Entry is added in alphabetical order within the correct section
- [x] Entry follows the format: `[Name](link) ![badges] - Description.`
- [x] Description does not start with "A" or "An"
- [x] Description is under 24 words
- [x] Commit is signed
- [x] One suggestion per PR

### Evidence of Tauri usage

GitSquid v2 is built with Tauri 2.x (Rust backend + React frontend). Evidence:
- Dependencies include `@tauri-apps/api`, `@tauri-apps/plugin-updater`, `@tauri-apps/plugin-process` etc.
- The app uses Tauri's IPC system (`invoke()` from `@tauri-apps/api/core`) for all backend communication
- Binary size is ~23MB (typical for Tauri, not Electron)
- The [blog post about the Electron to Tauri rewrite](https://gitsquid.dev/blog/why-we-rewrote-electron-in-tauri-rust) documents the migration