### PR TITLE
Add GT Office - multi-agent collaborative workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [GitButler](https://gitbutler.com) - GitButler is a new Source Code Management system.
 - [Github Security Alerts](https://github.com/stephanebouget/github-security-alerts) ![v2] - Monitors security vulnerabilities across your GitHub repositories in real-time.
 - [GitLight](https://github.com/colinlienard/gitlight) - GitHub & GitLab notifications on your desktop.
+- [GT Office](https://github.com/Laplace-bit/GT-Office) ![v2] - Native multi-agent collaborative workspace to orchestrate AI CLI tools (Claude Code, Codex, Gemini CLI) with persistent workspaces and agent-to-agent communication.
 - [JET Pilot](https://www.jet-pilot.app) - Kubernetes desktop client that focuses on less clutter, speed and good looks.
 - [Hoppscotch](https://hoppscotch.com/download) ![closed source] - Trusted by millions of developers to build, test and share APIs.
 - [Keadex Mina](https://github.com/keadex/keadex) - Open Source, serverless IDE to easily code and organize at a scale C4 model diagrams.


### PR DESCRIPTION
## Addition

- **Name:** GT Office
- **URL:** https://github.com/Laplace-bit/GT-Office
- **Category:** Applications > Developer tools

## Description

GT Office is a native multi-agent collaborative workspace desktop app built with Tauri v2, Rust, and React. It orchestrates AI CLI tools (Claude Code, Codex CLI, Gemini CLI) in a unified workspace with workspace-centric agent persistence, Agent-to-Agent communication bus (gto CLI), external channel proxy (Telegram, WeChat, Feishu), and cross-platform builds (macOS, Windows, Linux).

Open-source under Apache 2.0, actively maintained (v0.3.1, 10 releases).

## Checklist

- [x] Only one project/tool is added
- [x] Entry follows existing alphabetical order
- [x] Entry uses existing format: - [Name](link) ![v2] - Description.
- [x] Description is concise