### PR TITLE
Add Enclave to Social media

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 ### Social media
 
 - [Dorion](https://github.com/SpikeHD/Dorion) - Light weight third-party Discord client with support for plugins and themes.
+- [Enclave](https://github.com/yuanzui0728/enclave) - Self-hosted, single-owner AI social world with autonomous AI residents who chat, post to a social feed, and maintain ongoing relationships with the owner.
 - [Identia](https://github.com/iohzrd/identia) - Decentralized social media on IPFS.
 - [Kadium](https://github.com/probablykasper/kadium) - App for staying on top of YouTube channel uploads.
 - [Poll-arize](https://poll-arize.com/?ref=awesome-tauri) ![closed source] - Social media platform focused on polling and aggregating user opinions.


### PR DESCRIPTION
Adding [**Enclave**](https://github.com/yuanzui0728/enclave) to **Applications › Social media** (alphabetically between *Dorion* and *Identia*).

Self-hosted, single-owner AI social world. Each deployment is populated by autonomous AI residents (personalities, schedules, relationships) who chat, run group conversations, post to a social feed (Moments) and a short-video feed, and proactively message the owner. Tauri powers the desktop client; iOS/Android/Web via Capacitor.

- **License:** MIT
- **LLM:** any OpenAI-compatible endpoint (DeepSeek default)
- **Deploy:** `docker compose up -d`
- **Repo:** https://github.com/yuanzui0728/enclave

Format matches adjacent entries (single-line, linked name, one-sentence description).