### PR TITLE
Add Vibes to Audio & Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Screenpipe](https://github.com/mediar-ai/screenpipe) - 24/7 local AI screen & mic recording. Build AI apps with full context. Works with Ollama.
 - [SilentKeys](https://github.com/gptguy/silentkeys) ![v2] - Privacy-first, real-time dictation app built with Tauri, powered by `Parakeet ASR`, `Silero-VAD`, and on-device inference via `ORT`.
 - [ToneTempo](https://tonetempo.com) ![closed source] ![paid] - Workout and run with AutoMixed music and an AI fitness coach.
+- [Vibes](https://vibesdj.io/) ![closed source] ![paid] ![v2] - DJ library organizer that sorts tracks by mood, energy, and technique. Exports prepped crates to Rekordbox, Serato DJ, Engine DJ, and Lexicon DJ.
 - [Voxly](https://github.com/ibrahimshadev/dikt) ![v2] - Voice dictation app with AI modes that clean up speech before pasting into any active app.
 - [Watson.ai](https://github.com/LatentDream/watson.ai) - Easily record and extract the most important information from your meetings.
 - [Whispering](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![v2] - Speech-to-text app. Press shortcut → speak → get text. Supports local and cloud transcription with AI transformations.


### PR DESCRIPTION
Adds Vibes — a Tauri-built DJ library organizer — to Audio & Video.

- Website: https://vibesdj.io/
- Platforms: macOS (Apple Silicon) and Windows (x64)
- Tauri: v2
- License: Commercial (closed source, paid)

Vibes sorts DJ tracks by mood, energy, and technique, then exports prepped crates to Rekordbox, Serato DJ, Engine DJ, and Lexicon DJ. Native desktop app. Fits alongside existing closed-source/paid entries in the section.