### PR TITLE
Add Projelli to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [PicSharp](https://github.com/AkiraBit/PicSharp) ![v2] - With powerful and richly configured compression functions, it helps you easily optimize images, providing outstanding performance and a convenient operation experience.
 - [Pomodoro](https://github.com/g07cha/pomodoro) - Time management tool based on Pomodoro technique.
 - [Progressive](https://github.com/h8moss/progressive)![v2] - Todo app with progress tracking. Supports task weighting, percentage completion, and parent/child tasks.
+- [Projelli](https://projelli.com) ![closed source] ![paid] ![v2] - Local-first AI workspace where every chat with Claude / GPT / Gemini becomes a real Markdown file on your hard drive. BYOK, source visible on GitHub, one-time pricing.
 - [Qopy](https://github.com/0PandaDEV/Qopy) - The fixed Clipboard Manager for Windows and Mac.
 - [Remind Me Again](https://github.com/probablykasper/remind-me-again) - Toggleable reminders app for Mac, Linux and Windows.
 - [Runtime](https://github.com/runtime-org/runtime) ![v2] - AI taskmate for web & office tools.


### PR DESCRIPTION
Adding Projelli, a local-first AI workspace built on Tauri 2.

What it is:
- Local-first AI workspace, every chat with Claude / GPT / Gemini becomes a real Markdown file on your hard drive
- Built on Tauri 2 + React 18 + TypeScript + Zustand + CodeMirror 6
- BYOK (Claude / OpenAI / Gemini / Ollama), no Projelli proxy server
- Source-available on GitHub (commercial license, not OSS)
- One-time pricing ($49 Pro / $99 Lifetime / $29 Founder's Launch for first 100)
- Cross-platform: Mac (signed + notarized), Windows (Azure-signed), Linux (.deb / .rpm / .AppImage)

Live: https://projelli.com
Source: https://github.com/projelli/projelli

Inserted alphabetically in the Productivity section between Progressive and Qopy. Used the standard ![closed source] ![paid] ![v2] flags.