### PR TITLE
Add Platypus to Applications > Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Obliqoro](https://github.com/mrjackwills/obliqoro) - Oblique Strategies meets Pomodoro.
 - [PasteBar](https://github.com/PasteBar/PasteBarApp) - Limitless, Free Clipboard Manager for Mac and Windows. Effortless management of everything you copy and paste.
 - [PicSharp](https://github.com/AkiraBit/PicSharp) ![v2] - With powerful and richly configured compression functions, it helps you easily optimize images, providing outstanding performance and a convenient operation experience.
+- [Platypus](https://github.com/pixelsmasher13/platypus) - Local meeting transcription, note-taking, and chat with your knowledge base. Bring your own LLM.
 - [Pomodoro](https://github.com/g07cha/pomodoro) - Time management tool based on Pomodoro technique.
 - [Progressive](https://github.com/h8moss/progressive)![v2] - Todo app with progress tracking. Supports task weighting, percentage completion, and parent/child tasks.
 - [Qopy](https://github.com/0PandaDEV/Qopy) - The fixed Clipboard Manager for Windows and Mac.


### PR DESCRIPTION
Adding Platypus, an open-source desktop app for local meeting transcription, note-taking, and RAG chat over your knowledge base.

- Repo: https://github.com/pixelsmasher13/platypus
- Site: https://platypusnotes.com
- Release: v0.1.0 (signed/notarized macOS .dmg)
- Built with Tauri v1, Rust + React/TS frontend, whisper.cpp for local transcription

Entry placed alphabetically in `Applications > Productivity` (between PicSharp and Pomodoro).