### PR TITLE
Add Binderus — local-first Markdown editor (Tauri+Rust, ~9 MB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Astro Editor](https://github.com/dannysmith/astro-editor) - Clean markdown editor for Astro content collections with frontmatter editing, component insertion, and writing-focused interface.
 - [fylepad](https://github.com/imrofayel/fylepad/) - Notepad with powerful rich-text editing, built with Vue & Tauri.
 - [Bidirectional](https://github.com/samirdjelal/bidirectional) - Write Arabic text in apps that don't support bidirectional text.
+- [Binderus](https://github.com/binderus/binderus) - Local-first Markdown notes with Notion-style WYSIWYG editing on plain `.md` files, plugin system, custom themes (drop-in CSS with `extends:` inheritance), and encrypted vaults via libSQL. ~9 MB, Win/Mac/Linux.
 - [Blank](https://github.com/FPurchess/blank) - Minimalistic, opinionated markdown editor made for writing.
 - [Blinko](https://github.com/blinkospace/blinko) ![v2] - Self-hosted personal AI note tool prioritizing privacy.
 - [Ensō](https://enso.sonnet.io) ![closed source] - Write now, edit later. Ensō is a writing tool that helps you enter a state of flow.


### PR DESCRIPTION
Adds [Binderus](https://github.com/binderus/binderus) to the list — a free,
local-first Markdown note-taking app with Notion-style WYSIWYG editing on
plain `.md` files. Tauri + Rust, ~9 MB installer, Windows/macOS/Linux.

Project links:
- Website: https://www.binderus.com
- Source: https://github.com/binderus/binderus
- Releases: https://www.binderus.com/download