### PR TITLE
Add Deepend to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [claws](https://clawsapp.com/) ![closed source] - Visual interface for the AWS CLI.
 - [CrabNebula DevTools](https://crabnebula.dev/devtools) - Visual tool for understanding your app. Optimize the development process with easy debugging and profiling.
 - [CrabNebula DevTools Premium](https://crabnebula.dev/devtools) ![closed source] ![paid] - Optimize the development process with easy debugging and profiling. Debug the Rust portion of your app with the same comfort as JavaScript!
+- [Deepend](https://github.com/deepen-stha/deepend-releases) - Collection of 43 offline-first developer utilities — JSON, PDF, text, API, and image tools, all in one app.
 - [DevBox](https://www.dev-box.app/) ![closed source] - Many useful tools for developers, like generators, viewers, converters, etc.
 - [DevClean](https://github.com/HuakunShen/devclean) - Clean up development environment with ease.
 - [DevTools-X](https://github.com/fosslife/devtools-x) - Collection of 30+ cross platform development utilities.


### PR DESCRIPTION
Adds [Deepend](https://github.com/deepen-stha/deepend-releases) to the Developer tools section.

Deepend is a Tauri 2 desktop app that bundles 43 offline-first developer utilities into a single window:

- **JSON Studio** — format, repair, diff, query, redact, types generator, JWT decoder, RFC 6902 patch, mock generator, and more
- **Text Studio** — hash, diff, regex, encode, case transforms, readability, frequency, random
- **PDF Toolkit** — merge, split, compress, encrypt, sign, organize, render to image
- **API Studio** — HTTP request, cURL converter, code generator (7 languages), load test, Postman-compatible collections
- **PixelForge** — full image editor, EXIF inspector, format converter, color picker

Everything runs locally — no accounts, no uploads, no telemetry. Released under MIT.

Tested on Windows, macOS (Apple Silicon + Intel), and Linux. Installers are published to a public mirror repository (linked above) while the source is in a private repo.

Entry inserted alphabetically between **CrabNebula DevTools Premium** and **DevBox**.