### PR TITLE
Add balchat: E2E messenger over Tor onion services

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 
 ### Social media
 
+- [balchat](https://github.com/xandru582/balchat) ![v2] - End-to-end-encrypted (MLS / RFC 9420) 1:1 and group messenger over Tor onion services. Pure-Rust Tor stack via arti-client. Single Svelte 5 codebase auto-selects desktop layout (vibrancy, traffic-light overlay) or Android stack-router by viewport. No phone, no email, no central server.
 - [Dorion](https://github.com/SpikeHD/Dorion) - Light weight third-party Discord client with support for plugins and themes.
 - [Identia](https://github.com/iohzrd/identia) - Decentralized social media on IPFS.
 - [Kadium](https://github.com/probablykasper/kadium) - App for staying on top of YouTube channel uploads.


### PR DESCRIPTION
Adds [balchat](https://github.com/xandru582/balchat) under **Applications → Social media** (kept alphabetical — placed before Dorion).

## What it is

balchat is a non-trivial Tauri 2 app exercising several of the framework's strengths:

- **Single Svelte 5 codebase** auto-selects between a desktop layout (Messages.app-style sidebar + chat, vibrancy via \`backdrop-filter\`, macOS title-bar overlay) and a mobile stack-router on Android. Detection via \`matchMedia('(max-width: 720px), (pointer: coarse)')\`.
- **Tauri 2 mobile** Android target shipped (signed APK, 42 MB) — runs the same Rust backend that drives the desktop binary.
- Cross-platform binaries verified on macOS arm64, Android arm64, Linux x86_64, Windows x86_64 (the last two via \`cargo zigbuild\`).

## Status

Apache-2.0. Active maintenance (latest release [v0.1.3](https://github.com/xandru582/balchat/releases/tag/v0.1.3) hours ago). Working binary downloads at [/releases/latest](https://github.com/xandru582/balchat/releases/latest). README explains what it does in both English-friendly TLDR and Spanish detail.

## Checklist

- [x] Repo is FOSS (Apache-2.0)
- [x] Maintained (latest commit < 1 week)
- [x] Has a working binary download
- [x] README explains what it does
- [x] Entry follows the format of nearby items (alphabetical placement, same dash style, includes ![v2] tag since it's Tauri 2)

Happy to move to a different category (e.g. \`Networking\`) if you'd prefer — \`Social media\` was the closest existing fit alongside [Vector](https://github.com/VectorPrivacy/Vector) which has a similar pitch.