### PR TITLE
Add MinerU True Copy to Office & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [MarkFlowy](https://github.com/drl990114/MarkFlowy) - Modern markdown editor application with built-in ChatGPT extension.
 - [MD Viewer](https://github.com/kuyoonjo/md-viewer) - Cross-platform markdown viewer.
 - [MDX Notes](https://github.com/maqi1520/mdx-notes/tree/tauri-app) - Versatile WeChat typesetting editor and cross-platform Markdown note-taking software.
+- [MinerU True Copy](https://github.com/adoistic/mineru-true-copy) ![v2] - Desktop OCR for PDFs with layout-preserving DOCX, PPTX, and PDF export. Vision-LLM OCR keeps bold and italic; bundled IndicTrans2 sidecar for Indic translation.
 - [Noor](https://noor.to/) ![closed source] - Chat app for high-performance teams. Designed for uninterrupted deep work and rapid collaboration.
 - [Notpad](https://github.com/Muhammed-Rahif/Notpad) - Cross-platform rich text editor with a notepad interface, enhanced with advanced features beyond standard notepad.
 - [Parchment](https://github.com/tywil04/parchment) - Simple local-only cross-platform text editor with basic markdown support.


### PR DESCRIPTION
Adds [MinerU True Copy](https://github.com/adoistic/mineru-true-copy) under **Office & Writing**, alphabetical, between MDX Notes and Noor.

Tauri v2 desktop app that turns PDFs into editable DOCX, PPTX, and PDF while preserving the original page layout. OCR uses MinerU's pipeline; cloud mode (BYO OpenRouter key) routes the OCR slot to a vision-language model so bold and italic spans survive. A bundled IndicTrans2 sidecar adds Indic translation. macOS Apple Silicon at v0.1; AGPL-3.0 (forced by upstream MinerU).
