### PR TITLE
Add Vayou to Audio & Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Screenpipe](https://github.com/mediar-ai/screenpipe) - 24/7 local AI screen & mic recording. Build AI apps with full context. Works with Ollama.
 - [SilentKeys](https://github.com/gptguy/silentkeys) ![v2] - Privacy-first, real-time dictation app built with Tauri, powered by `Parakeet ASR`, `Silero-VAD`, and on-device inference via `ORT`.
 - [ToneTempo](https://tonetempo.com) ![closed source] ![paid] - Workout and run with AutoMixed music and an AI fitness coach.
+- [Vayou](https://github.com/0hgawa/vayou-desktop) ![v2] - Desktop video player built on libmpv, with multi-track subtitles, OpenSubtitles search, and on-the-fly subtitle translation.
 - [Voxly](https://github.com/ibrahimshadev/dikt) ![v2] - Voice dictation app with AI modes that clean up speech before pasting into any active app.
 - [Watson.ai](https://github.com/LatentDream/watson.ai) - Easily record and extract the most important information from your meetings.
 - [Whispering](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![v2] - Speech-to-text app. Press shortcut → speak → get text. Supports local and cloud transcription with AI transformations.


### PR DESCRIPTION
Adds [Vayou](https://github.com/0hgawa/vayou-desktop) to the Audio & Video section.

Vayou is a free, open-source desktop video player for Windows, built on Tauri 2 + Svelte 5 + Rust, using libmpv as the playback engine. Notable features:

- Multi-track audio and subtitles with per-file persistence
- OpenSubtitles search and download
- On-the-fly subtitle translation into 12 languages, preserving ASS styling
- 10-band equalizer, A–B loop, sleep timer, custom keybindings
- 13 UI languages
- File associations for 11 video and 8 audio extensions

License: MIT.

Inserted in alphabetical order between ToneTempo and Voxly.