### PR TITLE
Add DocsReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Bidirectional](https://github.com/samirdjelal/bidirectional) - Write Arabic text in apps that don't support bidirectional text.
 - [Blank](https://github.com/FPurchess/blank) - Minimalistic, opinionated markdown editor made for writing.
 - [Blinko](https://github.com/blinkospace/blinko) ![v2] - Self-hosted personal AI note tool prioritizing privacy.
+- [DocsReader](https://github.com/anbturki/docsreader) ![v2] - Markdown reader that organizes any folder of `.md` files into workspaces with Tree, Recent, Tags, and Pinned lenses.
 - [Ensō](https://enso.sonnet.io) ![closed source] - Write now, edit later. Ensō is a writing tool that helps you enter a state of flow.
 - [Fluster](https://flusterapp.com) ![v2] - The one stop, free and open source note taking application for everything a modern academic or STEM professional needs.
 - [Handwriting keyboard](https://github.com/BigIskander/Handwriting-keyboard-for-Linux-tesseract) - Handwriting keyboard for Linux X11 desktop environment.


### PR DESCRIPTION
## Description

Adds DocsReader to the Office & Writing section: a Tauri 2 + React + Rust desktop Markdown reader. Free, source available, code-signed and Apple-notarized on macOS.

Repo: https://github.com/anbturki/docsreader

## Checklist

- [x] One suggestion per pull request
- [x] Description is under 24 words
- [x] Description does not start with 'A' or 'An'
- [x] No links or parentheses in the description
- [x] Entry inserted alphabetically (between Blinko and Ensō)
- [x] App is built with Tauri 2 (`v2` badge applied)