### PR TITLE
Add tauri-plugin-pilot to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-plugin-network](https://github.com/HuakunShen/tauri-plugin-network) - Tools for reading network information and scanning network.
 - [tauri-plugin-nosleep](https://github.com/pevers/tauri-plugin-nosleep/) - Block the power save functionality in the OS.
 - [tauri-plugin-ota](https://github.com/inKibra/tauri-plugins/tree/main/packages/tauri-plugin-ota) - OTA plugin for applications that just want to continuously deliever new JavaScript code based on a manfiest.
+- [tauri-plugin-pilot](https://github.com/mpiton/tauri-pilot) ![v2] - Interactive CLI to inspect, interact with, and debug live apps: accessibility snapshots, JS eval, screenshots, console capture.
 - [tauri-plugin-pinia](https://github.com/ferreira-tb/tauri-store/tree/main/packages/plugin-pinia) - Persistent Pinia stores for Vue.
 - [tauri-plugin-prevent-default](https://github.com/ferreira-tb/tauri-plugin-prevent-default) - Disable default browser shortcuts.
 - [tauri-plugin-python](https://github.com/marcomq/tauri-plugin-python/) - Use python in your backend.


### PR DESCRIPTION
[tauri-plugin-pilot](https://github.com/mpiton/tauri-pilot) — debug-only plugin and CLI for inspecting and driving Tauri v2 apps from outside the process.

- Tauri v2, MIT, Linux/macOS/Windows
- Two crates on crates.io: `tauri-plugin-pilot` and `tauri-pilot-cli`, both at 0.5.0
- Plugin compiles under `#[cfg(debug_assertions)]`, so it's stripped from release builds
- JSON-RPC 2.0 over a Unix socket on Linux/macOS, Named Pipe on Windows

Placed alphabetically in **Plugins**, between `tauri-plugin-ota` and `tauri-plugin-pinia`.

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
- [x] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v1** add the `![v1]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v2** add the `![v2]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [ ] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional).

### Plugins/Integrations

- [x] Works with **Tauri 2.x or later**.
- [x] The project is open source and accepts contributions.
- [x] The repo is at least 30 days old.
- [x] Documentation is in English.
- [x] The project is active and maintained.

### Templates

<!-- Ignore unless you're contributing to Templates -->

### Apps

<!-- Ignore unless you're contributing to Apps -->

### Additional Context

I built this because I wanted Claude Code to be able to drive a Tauri app I was working on, same idea as Playwright for browsers, but for Tauri's WebView. The CLI handles accessibility-tree snapshots, JS eval, screenshots, and console capture. It's not AI-specific, anything that can speak JSON-RPC over the socket works fine.

Repo: https://github.com/mpiton/tauri-pilot
Crates: https://crates.io/crates/tauri-plugin-pilot, https://crates.io/crates/tauri-pilot-cli
License: MIT
