### PR TITLE
Add cgui to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Aptakube](https://aptakube.com/) ![closed source] - Multi-cluster Kubernetes UI.
 - [Beadbox](https://beadbox.app) ![closed source] - Real-time visual dashboard for monitoring AI agent task coordination, dependencies, and handoffs.
 - [Brew Services Manage](https://github.com/persiliao/brew-services-manage)![closed source] macOS Menu Bar application for managing Homebrew services.
+- [cgui](https://github.com/elementalcollision/cgui-visual) ![v2] - Visual GUI for Apple's `container` runtime on macOS — manage containers, images, volumes, networks, stacks, and stream logs.
 - [claws](https://clawsapp.com/) ![closed source] - Visual interface for the AWS CLI.
 - [CrabNebula DevTools](https://crabnebula.dev/devtools) - Visual tool for understanding your app. Optimize the development process with easy debugging and profiling.
 - [CrabNebula DevTools Premium](https://crabnebula.dev/devtools) ![closed source] ![paid] - Optimize the development process with easy debugging and profiling. Debug the Rust portion of your app with the same comfort as JavaScript!


### PR DESCRIPTION
This is the link to the project: [cgui](https://github.com/elementalcollision/cgui-visual)

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] If the project/article uses Tauri **v2** add the `![v2]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.

### Apps

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure.

### Additional Context

cgui is a Tauri 2 desktop GUI for Apple's `container` CLI on macOS — the visual companion to the [`cgui` ratatui TUI](https://github.com/elementalcollision/cgui). MIT-licensed, universal-binary releases via tauri-action with minisign-signed updater manifests on GitHub Pages, ~250 KB initial bundle, ~55 tests across Rust + vitest.

Tagged release v0.1.0: https://github.com/elementalcollision/cgui-visual/releases/tag/v0.1.0