### PR TITLE
Add Ikenga iyke (MCP control bridge) to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [axios-tauri-api-adapter](https://github.com/persiliao/axios-tauri-api-adapter) - Makes it easy to use Axios in Tauri, `axios` adapter for the `@tauri-apps/api/http` module.
 - [Deno in Tauri](https://github.com/typed-sigterm/deno-in-tauri) - Run JS/TS code with Deno Core Engine, in Tauri apps.
 - [faynosync-update-server](https://github.com/ku9nov/faynoSync) - Self-hosted Dynamic Update Server with statistics, supporting Tauri and other platforms. Flexible features for seamless app updates and insights.
+- [Ikenga iyke (MCP control bridge)](https://github.com/Royalti-io/ikenga-pkg-mcp-iyke) ![v2] - Drive a running Tauri 2 app from any MCP client (Claude, Cursor, etc.) — read DOM, click, type, navigate, screenshot.
 - [kkrpc](https://github.com/kunkunsh/kkrpc) - Seamless RPC communication between a Tauri app and node/deno/bun processes, just like Electron.
 - [ngx-tauri](https://codeberg.org/crapsilon/ngx-tauri) - Small lib to wrap around functions from tauri modules, to integrate easier with Angular.
 - [svelte-tauri-filedrop](https://github.com/probablykasper/svelte-tauri-filedrop) - File drop handling component for Svelte.


### PR DESCRIPTION
Adds an entry for [Ikenga iyke](https://github.com/Royalti-io/ikenga-pkg-mcp-iyke) under `### Integrations`.

**What it does:** A Model Context Protocol (MCP) server that drives a *running* Tauri 2 app from any MCP client (Claude Desktop, Cursor, etc.) — read DOM, click, type, navigate, capture screenshots, inspect mini-app state. Distinct from `tauri-mcp-server` (which is for development/debugging), this targets controlling deployed Tauri apps at runtime.

**Stack:** Node 20+, TypeScript, Apache 2.0, npm `@ikenga/mcp-iyke`, also listed on the official MCP registry (`io.github.Royalti-io/ikenga-pkg-mcp-iyke`).

Inserted alphabetically between `faynosync-update-server` and `kkrpc`. Tagged `![v2]` per the section convention.