### PR TITLE
Add marka.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Handwriting keyboard](https://github.com/BigIskander/Handwriting-keyboard-for-Linux-tesseract) - Handwriting keyboard for Linux X11 desktop environment.
 - [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable, offline-first Markdown editor. Single exe, no install, zero telemetry.
 - [JournalV](https://github.com/ahmedkapro/journalv) - Journaling app for your days and dreams.
+- [marka.md](https://github.com/mattenarle10/markamd) - Local-first macOS markdown editor for organizing AI context files, with IDE-style folder sidebar and one-keystroke clean-clipboard copy.
 - [MarkFlowy](https://github.com/drl990114/MarkFlowy) - Modern markdown editor application with built-in ChatGPT extension.
 - [MD Viewer](https://github.com/kuyoonjo/md-viewer) - Cross-platform markdown viewer.
 - [MDX Notes](https://github.com/maqi1520/mdx-notes/tree/tauri-app) - Versatile WeChat typesetting editor and cross-platform Markdown note-taking software.


### PR DESCRIPTION
Adds [marka.md](https://github.com/mattenarle10/markamd) — a local-first macOS + Windows markdown editor specialized for organizing AI context files.

- **Built with**: Tauri 2 + React 19 + TypeScript 5.8
- **Open source**: MIT
- **Latest**: v1.1.0 (2026-05-17) — now cross-platform **macOS + Windows**, Linux coming next
- **Status**: notarized on macOS + auto-updating cross-platform via tauri-plugin-updater
- **Adoption**: 100+ installs in first 48h, 33 active users on auto-update
- **Site**: https://markamd.vercel.app
- **Product Hunt**: https://www.producthunt.com/products/marka-md

Per CONTRIBUTING.md:
- [x] Format: `[Title](link) - Description.`
- [x] Description under 24 words (23)
- [x] Description does not start with "A" or "An"
- [x] No filler words like "for Tauri"
- [x] Alphabetical placement (between JournalV and MarkFlowy)
- [x] Open source (MIT)
- [x] English README
- [x] One suggestion per PR

Happy to update the entry to `![v2]` badge once merged, since v1.1.0 ships on Tauri 2.x with the auto-updater plugin wired.