### PR TITLE
Add Keyboard Lock OSD to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Get Unique ID](https://github.com/hiql/get-unique-id-app) - Generates unique IDs for you to use in debugging, development, or anywhere else you may need a unique ID.
 - [Happy](https://github.com/thewh1teagle/happy) - Control HappyLight compatible LED strip with ease.
 - [Imagenie](https://github.com/zhongweili/imagenie) - AI-powered desktop app for stunning image transformations
+- [Keyboard Lock OSD](https://github.com/coderDJing/keyboard-lock-osd) ![v2] - Lightweight Windows OSD for Caps Lock, Num Lock, and Scroll Lock state changes.
 - [KoS - Key on Screen](https://github.com/dubisdev/key-on-screen) - Show in your screen the keys you are pressing.
 - [Lanaya](https://github.com/ChurchTao/Lanaya) - Easy to use, cross-platform clipboard management.
 - [Lingo](https://github.com/thewh1teagle/lingo) - Translate offline in every language on every platform.


### PR DESCRIPTION
## What

Add [Keyboard Lock OSD](https://github.com/coderDJing/keyboard-lock-osd) to the **Utilities** section.

## Why

Keyboard Lock OSD is a lightweight Windows utility that shows a compact on-screen indicator for Caps Lock, Num Lock, and Scroll Lock changes. It's built with Tauri v2 and is useful for laptop users whose keyboards lack visible lock-key indicators.

## Features
- Instant OSD feedback for lock key state changes
- Per-key overlay controls
- Fullscreen suppression for games/presentations
- Tray-first startup with optional start at login
- English and Chinese UI