### PR TITLE
Add Victauri to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-plugin-view](https://github.com/ecmel/tauri-plugin-view) - View and share files on mobile.
 - [tauri-remote-ui](https://github.com/DraviaVemal/tauri-remote-ui) - Make you web app bundle available as web page for test and development.
 - [taurpc](https://github.com/MatsDK/TauRPC) - Typesafe IPC wrapper for Tauri commands and events.
+- [Victauri](https://github.com/4DA-Systems/victauri) ![v2] - Full-stack testing and introspection: DOM, IPC, Rust backend, and database from one test or AI agent (MCP) - no WebDriver or CDP.
 
 ### Integrations
 


### PR DESCRIPTION
Adds [Victauri](https://github.com/4DA-Systems/victauri) to the Plugins section — an Apache-2.0 Tauri 2 plugin for full-stack testing and introspection: DOM, IPC, Rust backend state, and database access from one test (or an AI agent via MCP), with no WebDriver or CDP dependency. Debug-builds-only by design (`#[cfg(debug_assertions)]`-gated).

- 6 crates on crates.io (`victauri-plugin`, `victauri-cli`, `victauri-test`, …), v0.8.5
- CI on Windows/macOS/Linux; validated against real Tauri apps (Kanri, En Croissant, Surrealist, Duckling, Lettura) with zero app changes
- Docs: https://4da-systems.github.io/Victauri/

(Rebased onto current HEAD and moved from Integrations to Plugins — it is a Tauri plugin, so Plugins is the accurate section.)