### PR TITLE
Add ShowMe and catchem to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Upcount](https://www.upcount.app/) ![v2] - Free invoicing and time tracking application for freelancers and small businesses.
 - [UsTaxes](https://github.com/ustaxes/ustaxes) - Free, private, open-source US tax filings.
 - [Wealthfolio](https://wealthfolio.app) - Simple, open-source desktop portfolio tracker that keeps your financial data safe on your computer.
+- [ShowMe](https://github.com/nazmiefearmutcu/showMe) - Native macOS market cockpit with 12-timeframe consensus scan over 3370 symbols (crypto + equity + ETF + FX + commodity + bond), 23-indicator engine, signed updater. Tauri shell + Python sidecar.
+- [catchem](https://github.com/nazmiefearmutcu/catchem) - Local-first finance-relevance sidecar that turns web text captures into multi-labeled FinancialImpactRecord events with an analyst UI. FastAPI engine + Tauri 2 shell.
 
 ### Gaming
 


### PR DESCRIPTION
Adding two Tauri-based open-source finance projects to the **Applications > Finance** section:

**[ShowMe](https://github.com/nazmiefearmutcu/showMe)** — native macOS market cockpit. 12-timeframe consensus scan over 3370 symbols (crypto + equity + ETF + FX + commodity + bond), 23 technical indicators with per-market calibration. Tauri shell (Rust) + signed updater + Python sidecar (FastAPI) + React + TypeScript UI. 130k LOC, ~600 tests. MIT.

**[catchem](https://github.com/nazmiefearmutcu/catchem)** — local-first finance-relevance sidecar that turns raw web text into labeled finance signals. FastAPI engine emits multi-label FinancialImpactRecord events; Tauri 2 + React analyst UI (7 MB .app). 220+ pytest + 30+ vitest. MIT.

Both have working .app builds and a Preview section with real screenshots in their READMEs.