### PR TITLE
Add tauri-plugin-keyring-store to Awesome Tauri

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-plugin-in-app-review](https://github.com/Gbyte-Group/tauri-plugin-in-app-review) ![v2] - In-app app rating prompts using native platform APIs.
 - [tauri-plugin-ios-photos](https://github.com/Gbyte-Group/tauri-plugin-ios-photos) ![v2] - iOS Photos album and asset management via native APIs.
 - [tauri-plugin-js](https://github.com/HuakunShen/tauri-plugin-js) ![v2] - Give your app Electron-like JS backends with type-safe RPC powered by `kkrpc`. Supports Bun, Node.js, and Deno.
+- [tauri-plugin-keyring-store](https://github.com/s00d/tauri-plugin-keyring-store) ![v2] - `tauri-plugin-stronghold` alternative with secure key storage and Rust-side management APIs.
 - [tauri-plugin-keep-screen-on](https://gitlab.com/cristofa/tauri-plugin-keep-screen-on) - Disable screen timeout on Android and iOS.
 - [tauri-plugin-macos-permissions](https://github.com/ayangweb/tauri-plugin-macos-permissions) - Support for checking and requesting macOS system permissions.
 - [tauri-plugin-mobile-sharetarget](https://github.com/IT-ess/tauri-plugin-mobile-sharetarget) ![v2] - Handle mobile Share Intents with a FIFO queue


### PR DESCRIPTION
This is the link to the project: [tauri-plugin-keyring-store](https://github.com/s00d/tauri-plugin-keyring-store)

### Development > Plugins

- Added one entry in alphabetical order:
  - `[tauri-plugin-keyring-store](https://github.com/s00d/tauri-plugin-keyring-store) ![v2] - \`tauri-plugin-stronghold\` alternative with secure key storage and Rust-side management APIs.`

### Checklist

- [x] I have read the contributing guidelines.
- [x] Uses required `[Title](link) - Description.` format.
- [x] One suggestion in this pull request.
- [x] Description is under 24 words and does not start with `A` or `An`.
- [x] Added alphabetically to the most appropriate category.

Made with [Cursor](https://cursor.com)