### PR TITLE
Add Markup (Office & Writing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable, offline-first Markdown editor. Single exe, no install, zero telemetry.
 - [JournalV](https://github.com/ahmedkapro/journalv) - Journaling app for your days and dreams.
 - [MarkFlowy](https://github.com/drl990114/MarkFlowy) - Modern markdown editor application with built-in ChatGPT extension.
+- [Markup](https://github.com/oratis/Markup) ![v2] - Reader-first, native macOS Markdown editor: renders notes like a web page and edits on demand, with a vault, backlinks, graph, and full-text search.
 - [MD Viewer](https://github.com/kuyoonjo/md-viewer) - Cross-platform markdown viewer.
 - [MDX Notes](https://github.com/maqi1520/mdx-notes/tree/tauri-app) - Versatile WeChat typesetting editor and cross-platform Markdown note-taking software.
 - [Noor](https://noor.to/) ![closed source] - Chat app for high-performance teams. Designed for uninterrupted deep work and rapid collaboration.


### PR DESCRIPTION
Adds **Markup** to *Applications → Office & Writing*.

- **Repo:** https://github.com/oratis/Markup
- **What it is:** a free, open-source (MIT), native macOS Markdown editor built on Tauri 2.
- **Why it fits:** reader-first — it renders your Markdown like a clean web page by default and you edit on demand (WYSIWYG via Milkdown, or raw source). Includes a vault with wikilinks/backlinks/graph and Tantivy full-text search.

Entry placed alphabetically between `MarkFlowy` and `MD Viewer`, with the `![v2]` badge (Tauri 2). Format mirrors the existing Office & Writing entries.