### PR TITLE
Add Whisper by Remskill to Audio & Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [ToneTempo](https://tonetempo.com) ![closed source] ![paid] - Workout and run with AutoMixed music and an AI fitness coach.
 - [Voxly](https://github.com/ibrahimshadev/dikt) ![v2] - Voice dictation app with AI modes that clean up speech before pasting into any active app.
 - [Watson.ai](https://github.com/LatentDream/watson.ai) - Easily record and extract the most important information from your meetings.
+- [Whisper by Remskill](https://whisper.remskill.com) ![v2] ![closed source] - Hotkey voice-to-text with real-time web search built in; local Whisper or Parakeet, or cloud OpenAI, pasted at the cursor in any app.
 - [Whispering](https://github.com/EpicenterHQ/epicenter/tree/main/apps/whispering) ![v2] - Speech-to-text app. Press shortcut → speak → get text. Supports local and cloud transcription with AI transformations.
 - [XGetter](https://github.com/xgetter-team/xgetter) ![closed source]- Cross-platform GUI to download videos and audio from Youtube, Facebook, X(Twitter), Instagram, Tiktok and more.
 - [yt-dlp GUI](https://github.com/gaeljacquin/yt-dlp-gui) - Cross-platform GUI client for the `yt-dlp` command-line audio/video downloader.


### PR DESCRIPTION
Adds **Whisper by Remskill** — a hotkey voice-to-text app built with Tauri v2, with built-in real-time web search.

**Differentiator vs existing entries:** bundles local Whisper, local Parakeet (NVIDIA TDT), and cloud OpenAI in one app so users pick the engine per task. Built-in real-time web search lets you speak a question and get the answer pasted at the cursor — not just transcription.

- Homepage: https://whisper.remskill.com
- Tauri: v2
- Platforms: macOS Apple Silicon + Windows
- Source: closed source (badge included)

Disclosure: I'm the maintainer.