### PR TITLE
Add Quill ebook reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 
 - [Alexandria](https://github.com/btpf/Alexandria) - Minimalistic cross-platform eBook reader.
 - [Jane Reader](https://janereader.com) ![closed source] - Modern and distraction-free epub reader.
+- [Quill](https://github.com/yicheng47/quill) ![v2] - Ebook reader with EPUB/PDF support, contextual AI assistance, vocabulary review, and iCloud sync.
 - [Readest](https://github.com/chrox/readest) - Modern and feature-rich ebook reader designed for avid readers.
 - [Cloak](https://github.com/Xav1erSue/cloak) - A see-through mini reader for slacking off at work.
 


### PR DESCRIPTION
Adds [Quill](https://github.com/yicheng47/quill) to the **Ebook readers** section.

Quill is an ebook reader for EPUB and PDF with a contextual AI assistant, vocabulary review, and iCloud sync across Mac, iPhone, and iPad. Built with Tauri v2, open source (MIT).

- Repo: https://github.com/yicheng47/quill
- Tauri v2 (badged with `![v2]`)
- Placed alphabetically within Ebook readers
