### PR TITLE
Add MQLens

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [DocKit](https://github.com/geek-fun/dockit) - GUI client for NoSQL databases such as elasticsearch, OpenSearch, etc.
 - [Duckling](https://github.com/l1xnan/duckling) - Lightweight and fast viewer for csv/parquet files and databases such as DuckDB, SQLite, PostgreSQL, MySQL, Clickhouse, etc.
 - [Elasticvue](https://elasticvue.com/) - Free and open-source Elasticsearch GUI
+- [MQLens](https://mqlens.com) ![v2] - Native MongoDB GUI with every auth mode, TLS/SSH/SOCKS5, aggregation pipelines, schema analysis, GridFS, embedded `mongosh`, and optional AI query assistant.
 - [Noir](https://noirdb.dev) - Keyboard-driven database management client.
 - [pgMagic🪄](https://pgmagic.app/?ref=awesometauri) ![closed source] ![paid] - GUI client to talk to Postgres in SQL or with natural language.
 - [qsv pro](https://qsvpro.dathere.com) ![closed source] ![paid] - Explore spreadsheet data including CSV in interactive data tables with generated metadata and a node editor based on the `qsv` CLI.


### PR DESCRIPTION
Adds [MQLens](https://mqlens.com) to **Applications → Data** (alphabetically between Elasticvue and Noir).

MQLens is a free, open-source (Apache-2.0) native MongoDB GUI built with **Tauri v2** (Rust) + React — every auth mode (SCRAM, X.509, AWS, Kerberos, LDAP), TLS/SSH/SOCKS5, aggregation pipelines with explain plans, schema analysis, GridFS, an embedded `mongosh`, and an optional AI query assistant. Encrypted local credentials, zero telemetry. macOS/Windows/Linux.

Repo: https://github.com/mqlens/mqlens-mongodb

Apps checklist:
- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure (native Tauri, encrypted local vault, no telemetry).
- [x] Open source, so no closed-source evidence needed.
- [x] Added alphabetically to the most appropriate category (Data).
- [x] Description is under 24 words, doesn't start with "A"/"An", no links/parentheses, backticks around `mongosh`.
- [x] One suggestion per pull request.
- [x] Commit is signed.