### PR TITLE
Add Huiyu MD - minimal Tauri-based Markdown reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Semanmeter](https://yibiao.fun/) ![closed source] - OCR and document conversion software.
 - [Ubiquity](https://github.com/opensourcecheemsburgers/ubiquity) - Cross-platform markdown editor; built with Yew, Tailwind, and DaisyUI.
 - [HuLa](https://github.com/HuLaSpark/HuLa) - HuLa is a desktop instant messaging app built on Tauri+Vue3 (not just instant messaging).
+- [Huiyu MD](https://github.com/huiyu9144/Huiyu-MD) ![v2] - Minimal, lightning-fast Markdown reader for Windows & macOS. Dark/Light themes, Ctrl+scroll zoom, KaTeX math, code highlighting.
 - [Gramax](https://github.com/Gram-ax/gramax) - Free, open-source application for creating, editing, and publishing Git-driven documentation sites using Markdown and a visual editor.
 
 ### Productivity


### PR DESCRIPTION
## What does this PR do?

Adds [Huiyu MD](https://github.com/huiyu9144/Huiyu-MD) to the Office & Writing section.

## Why should this be included?

Huiyu MD is a **minimal, lightning-fast** Markdown reader built with Tauri 2.0. Unlike Electron-based editors (~150-200MB), Huiyu MD is only **~5MB** and starts **instantly**.

### Key features:
- ⚡ Instant startup (< 0.3s, zero white flash)
- 🌙 Dark/Light themes (auto-persist)
- 🔍 Ctrl+scroll zoom (25% - 400%)
- 📐 KaTeX math formula support
- 💻 Code blocks with syntax highlighting + copy
- 🖱️ Drag & drop file opening
- 🍎 macOS (notarized) + 🪟 Windows

### Screenshots

![Dark Mode](https://raw.githubusercontent.com/huiyu9144/Huiyu-MD/main/docs/screenshots/dark-context.jpg)

![Light Mode](https://raw.githubusercontent.com/huiyu9144/Huiyu-MD/main/docs/screenshots/light-context.jpg)

### Links
- GitHub: https://github.com/huiyu9144/Huiyu-MD
- Website: https://www.huiyu.ai
- Latest Release: https://github.com/huiyu9144/Huiyu-MD/releases/tag/v1.5.0