### PR TITLE
Add Fluxlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Dwall](https://github.com/dwall-rs/dwall) - Change the Windows desktop and lock screen wallpapers according to the sun's azimuth and altitude angles, just like on macOS.
 - [Fancy Screen Recorder](https://fancyapps.com/freebies/) ![closed source] - Record entire screen or a selected area, trim and save as a GIF or video.
 - [FanslySync](https://github.com/SticksDev/FanslySync) - Sync your Fansly data with 3rd party applications, securely!
+- [Fluxlay](https://fluxlay.com) ![closed source] ![v2] - Live wallpapers for macOS and Windows; write a wallpaper as a React or Vue component and it runs natively on your desktop.
 - [Flying Carpet](https://github.com/spieglt/flyingcarpet) - File transfer between Android, iOS, Linux, macOS, and Windows over auto-configured hotspot.
 - [Get Unique ID](https://github.com/hiql/get-unique-id-app) - Generates unique IDs for you to use in debugging, development, or anywhere else you may need a unique ID.
 - [Happy](https://github.com/thewh1teagle/happy) - Control HappyLight compatible LED strip with ease.


### PR DESCRIPTION
This is the link to the project: [Fluxlay](https://fluxlay.com)

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
- [x] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v1** add the `![v1]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v2** add the `![v2]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [x] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional).

### Plugins/Integrations

<!-- Ignore unless you're contributing to Plugins/Integrations -->

- [ ] Works with **Tauri 2.x or later**.
- [ ] The project is open source and accepts contributions.
- [ ] The repo is at least 30 days old.
- [ ] Documentation is in English.
- [ ] The project is active and maintained.

### Templates

<!-- Ignore unless you're contributing to Templates -->

- [ ] Works with **Tauri 2.x or later**.
- [ ] The repo is at least 30 days old.
- [ ] Documentation is in English.
- [ ] The template provides enough information about how to get started and what's included.
- [ ] The template is pretty different from the existing templates.

### Apps

<!-- Ignore unless you're contributing to Apps -->

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure.
- [x] If the app is closed source, evidence of it being built with Tauri is included.

### Additional Context

Fluxlay is a free live wallpaper app for macOS and Windows built with Tauri 2 (Rust). Wallpapers are
written as React or Vue components and rendered natively on the desktop at up to 4K, with a hooks-based
SDK (`@fluxlay/react`) exposing audio spectrum, system stats, now-playing track, cursor data and even an
embeddable terminal. Image and video wallpapers can be published without code. It also ships a CLI and
a marketplace where creators publish and sell their work with DRM-protected delivery.

Playback is designed to stay lightweight: Rust-powered rendering with minimal resource usage, automatic
pause when an app goes fullscreen, and per-monitor / per-Space wallpaper support.

**Evidence of being built with Tauri 2** (the app is closed source): our technical write-up covering the
Tauri 2 + Rust architecture, IPC design and SDK internals (in Japanese, with code):
https://dev.to/ken109/i-built-a-live-wallpaper-engine-for-macos-heres-how-it-works-5ed
Happy to provide additional evidence if needed.

**Disclosure**: I'm part of the Fluxlay team. Sharing it because it's a genuine Tauri 2 app and a fit
for the Utilities list — happy to adjust the entry or category to match your guidelines.