### PR TITLE
Add Duckle to Applications > Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [BS Redis Desktop Client](https://github.com/fuyoo/bs-redis-desktop-client) - The Best Surprise Redis Desktop Client.
 - [Dataflare](https://dataflare.app) ![closed source] ![paid] - Simple and elegant database manager.
 - [DocKit](https://github.com/geek-fun/dockit) - GUI client for NoSQL databases such as elasticsearch, OpenSearch, etc.
+- [Duckle](https://github.com/SouravRoy-ETL/duckle) ![v2] - Visual-first ETL/ELT studio built on `DuckDB` that compiles drag-and-drop pipelines to plain SQL.
 - [Duckling](https://github.com/l1xnan/duckling) - Lightweight and fast viewer for csv/parquet files and databases such as DuckDB, SQLite, PostgreSQL, MySQL, Clickhouse, etc.
 - [Elasticvue](https://elasticvue.com/) - Free and open-source Elasticsearch GUI
 - [Noir](https://noirdb.dev) - Keyboard-driven database management client.


### PR DESCRIPTION
Adds [Duckle](https://github.com/SouravRoy-ETL/duckle) under **Applications > Data** (alphabetically, between DocKit and Duckling).

Duckle is a Tauri 2 desktop app: a visual-first ETL/ELT studio built on DuckDB that compiles a drag-and-drop canvas to plain SQL. It fits next to the other database/data tools already in that section (Duckling, DocKit, Dataflare).