### PR TITLE
Add Private Terminal to Finance apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Ghorbu Wallet](https://github.com/matthias-wright/ghorbu-wallet) - Cross-platform desktop HD wallet for Bitcoin.
 - [Mahalli](https://github.com/AbdelilahOu/Mahalli-tauri) - Local first inventory and invoicing management app.
 - [nym-wallet](https://github.com/nymtech/nym/tree/develop/nym-wallet) - The Nym desktop wallet enables you to use the Nym network and take advantage of its key capabilities.
+- [Private Terminal](https://github.com/cerkon1/private-terminal) ![v2] - Free, local-first research dashboard for stocks, crypto, and macroeconomics. No accounts, no telemetry.
 - [Spent](https://github.com/FrogSnot/Spent) ![v2] - Minimalist cross-platform personal finance tracker.
 - [Upcount](https://www.upcount.app/) ![v2] - Free invoicing and time tracking application for freelancers and small businesses.
 - [UsTaxes](https://github.com/ustaxes/ustaxes) - Free, private, open-source US tax filings.


### PR DESCRIPTION
Adds [Private Terminal](https://github.com/cerkon1/private-terminal) to the Finance section.

A free, MIT-licensed, local-first desktop research dashboard built on Tauri v2 (Rust backend + React/TypeScript frontend). Watchlist with multi-indicator candlestick charts, 29 FRED macro series, cross-section percentile heatmap, and seven cross-asset analysis tools. No accounts, no telemetry — all state lives in a local SQLite file.

Disclosure: I'm the author.

Entry is placed alphabetically and follows the existing format with the ![v2] badge.