### PR TITLE
Add atrium (Apps > Developer tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [AppCenter Companion](https://github.com/zenoxs/tauri-appcenter-companion) - Regroup, build and track your `VS App Center` apps.
 - [AppHub](https://github.com/francesco-gaglione/AppHub) - Streamlines .appImage package installation, management, and uninstallation through an intuitive Linux desktop interface.
 - [Aptakube](https://aptakube.com/) ![closed source] - Multi-cluster Kubernetes UI.
+- [atrium](https://getatrium.dev) ![closed source] ![v2] - Resumable workspace that runs Claude Code, Codex, Gemini and other coding agents side by side with terminals, browsers and session search.
 - [Beadbox](https://beadbox.app) ![closed source] - Real-time visual dashboard for monitoring AI agent task coordination, dependencies, and handoffs.
 - [Brew Services Manage](https://github.com/persiliao/brew-services-manage)![closed source] macOS Menu Bar application for managing Homebrew services.
 - [claws](https://clawsapp.com/) ![closed source] - Visual interface for the AWS CLI.


### PR DESCRIPTION
This is the link to the project: [atrium](https://getatrium.dev)

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
- [x] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v1** add the `![v1]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v2** add the `![v2]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [ ] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional).

### Apps

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure.
- [x] If the app is closed source, evidence of it being built with Tauri is included.

### Additional Context

Evidence atrium is built with Tauri (v2):

- The public update feed at https://getatrium.dev/api/releases/latest.json is the standard Tauri updater JSON format (`platforms.darwin-aarch64` / `darwin-x86_64` entries with minisign signatures, consumed by `tauri-plugin-updater`).
- The shipped `.app` bundle contains the Tauri/wry runtime and `tauri.conf`-derived metadata (bundle identifier `com.skybot.atrium`); happy to provide any further verification the maintainers would like.

atrium is free during early access. I'm the author.
