### PR TITLE
Add Better Resource Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Auto Wallpaper](https://github.com/auto-wallpaper/auto-wallpaper) - Automatically generates 4K wallpapers based on user's location, weather, and time of day or any custom prompts.
 - [bewCloud Desktop Sync](https://github.com/bewcloud/bewcloud-desktop) - Desktop sync app for bewCloud, a simpler alternative to Nextcloud and ownCloud.
 - [Basset](https://github.com/mohammadmansour200/basset) ![v2] - All-in-one offline media toolkit: cut, convert, compress, and remove instruments from audio, video, and images.
+- [Better Resource Monitor](https://github.com/alexx855/better-resource-monitor) ![v2] - Lightweight macOS menu bar monitor for CPU, memory, storage, GPU, and network usage.
 - [TypeView - KeyStroke Visualizer](https://github.com/dunkbing/typeview) - Visualizes keys pressed on the screen and simulates the sound of mechanical keyboard.
 - [Browsernaut](https://github.com/billyjacoby/browsernaut) - Browser picker for macOS.
 - [Clipboard Record](https://github.com/lesterhnu/clipboard) - Record Clipboard Content.


### PR DESCRIPTION
Adds Better Resource Monitor to the Utilities app list. It is a free open-source macOS menu bar monitor built with Tauri 2 and Rust.\n\nProject: https://github.com/alexx855/better-resource-monitor\nWebsite: https://better-resource-monitor.alexpedersen.dev/