### PR TITLE
Add Remember (local-first spaced-repetition flashcards)

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Japanese](https://github.com/meel-hd/japanese) - Learn Japanese Hiragana and Katakana. Memorize, write, pronounce, and test your knowledge.
 - [Manjaro Starter](https://github.com/oguzkaganeren/manjaro-starter) - Documentation and support app for new Manjaro users.
 - [Piano Trainer](https://github.com/ZaneH/piano-trainer) - Practice piano chords, scales, and more using your MIDI keyboard.
+- [Remember](https://github.com/linustalacko/remember) - Local-first spaced-repetition flashcards with Anki import and optional end-to-end sync.
 - [Solars](https://github.com/hiltontj/solars) - Visualize the planets of our solar system.
 - [Syre](https://github.com/syre-data/syre) - Scientific data assistant.
 - [Rosary](https://github.com/Roseblume/Rosary) - Study Christianity.


### PR DESCRIPTION
Adds **Remember** to *Applications → Learning*.

[Remember](https://github.com/linustalacko/remember) is a local-first, open-source spaced-repetition flashcard app (an open-source Anki) built with Tauri 2 + SvelteKit + Rust. It features a faithful SM-2 scheduler, Anki `.anki2` import (decks, cards, and full review history), and optional multi-device sync via a user-owned Turso (libSQL) database.

Guidelines checklist:
- [x] Format `[Title](link) - Description.`
- [x] Added alphabetically to the most appropriate category (Learning)
- [x] Description is under 24 words, no links/parentheses, and doesn't start with "A"/"An"
- [x] Open source (MIT), README in English, built with Tauri 2
- [x] One suggestion in this PR
