### PR TITLE
Add Direct Light

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Compresso](https://github.com/codeforreal1/compressO) - Cross-platform video compression app powered by FFmpeg.
 - [Cosmos](https://meetcosmos.com/) ![closed source] - Search your media library by describing scenes. Navigate terabytes with natural language, reverse image search, and audio transcription locally on your machine.
 - [Curses](https://github.com/mmpneo/curses) - Speech-to-Text and Text-to-Speech captions for OBS, VRChat, Twitch chat and more.
+- [Direct Light](https://github.com/oukeming64-tech/direct-light) ![v2] - Studio lighting previsualization sandbox for directors and cinematographers, with real-time light, shadow, and camera preview in a white studio.
 - [Douyin Downloader](https://github.com/lzdyes/douyin-downloader) - Cross-platform douyin video downloader.
 - [Feiyu Player](https://github.com/idootop/feiyu-player) - Cross-platform online video player where beauty meets functionality.
 - [Global Hotkey Spotify](https://github.com/Sid-V/global_hotkey_spotify) ![v2] - Control Spotify playback with custom global keyboard shortcuts, no media keys needed.


### PR DESCRIPTION
This is the link to the project: [Direct Light](https://github.com/oukeming64-tech/direct-light)

A white-studio lighting previsualization sandbox for directors, DPs, and gaffers — preview in real time how light position, fixtures, modifiers, and color shape a subject and its shadows. Built with Tauri 2 (universal macOS `.dmg` published in Releases).

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [ ] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
- [ ] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
- [ ] If the project/article uses Tauri **v1** add the `![v1]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v2** add the `![v2]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [ ] I have signed my commits (optional).

### Apps

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure.
- [ ] If the app is closed source, evidence of it being built with Tauri is included.

### Additional Context

Added under **Applications → Audio & Video**, alphabetically between `Curses` and `Douyin Downloader`. The project is open source (MIT). The main README is bilingual: a full English README is at [`README.en.md`](https://github.com/oukeming64-tech/direct-light/blob/main/README.en.md), linked from the top of the main README. The desktop build is a universal (arm64 + x86_64) macOS app published as a `.dmg` in [Releases](https://github.com/oukeming64-tech/direct-light/releases).
