### PR TITLE
Add JsonStudio to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Github Security Alerts](https://github.com/stephanebouget/github-security-alerts) ![v2] - Monitors security vulnerabilities across your GitHub repositories in real-time.
 - [GitLight](https://github.com/colinlienard/gitlight) - GitHub & GitLab notifications on your desktop.
 - [JET Pilot](https://www.jet-pilot.app) - Kubernetes desktop client that focuses on less clutter, speed and good looks.
+- [JsonStudio](https://github.com/sundegan/JsonStudio) ![v2] - Local-first JSON workspace for formatting, editing, diffing, converting, validating, and extracting JSON from logs.
 - [Hoppscotch](https://hoppscotch.com/download) ![closed source] - Trusted by millions of developers to build, test and share APIs.
 - [Keadex Mina](https://github.com/keadex/keadex) - Open Source, serverless IDE to easily code and organize at a scale C4 model diagrams.
 - [Keyring Demo](https://github.com/open-source-cooperative/keyring-rs/wiki/Keyring) ![v2] - GUI for the Rust `keyring` ecosystem


### PR DESCRIPTION
This is the link to the project: [JsonStudio](https://github.com/sundegan/JsonStudio)

Added entry:

```markdown
- [JsonStudio](https://github.com/sundegan/JsonStudio) ![v2] - Local-first JSON workspace for formatting, editing, diffing, converting, validating, and extracting JSON from logs.
```

Website: https://jsonstudio.js.org/

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] If the project/article uses Tauri **v2** add the `![v2]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [ ] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional).

### Apps

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure.
