### PR TITLE
Add Glimpse

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Curses](https://github.com/mmpneo/curses) - Speech-to-Text and Text-to-Speech captions for OBS, VRChat, Twitch chat and more.
 - [Douyin Downloader](https://github.com/lzdyes/douyin-downloader) - Cross-platform douyin video downloader.
 - [Feiyu Player](https://github.com/idootop/feiyu-player) - Cross-platform online video player where beauty meets functionality.
+- [Glimpse](https://github.com/glimpse-hq/Glimpse) ![v2] - On-device dictation with a custom dictionary, text replacements, and a library for transcribing audio and video files.
 - [Global Hotkey Spotify](https://github.com/Sid-V/global_hotkey_spotify) ![v2] - Control Spotify playback with custom global keyboard shortcuts, no media keys needed.
 - [Hopp](https://github.com/gethopp/hopp) ![v2] - Open source remote pair programming app.
 - [Hypetrigger](https://hypetrigger.io/) ![closed source] - Detect highlight clips in video with FFMPEG + Tensorflow on the GPU.


### PR DESCRIPTION
Adds Glimpse to Audio & Video. It is an on-device voice dictation app for macOS and Windows, built with Tauri v2.

Repo: https://github.com/glimpse-hq/Glimpse

It is open source (AGPL-3.0). Core dictation is free; some advanced features require a paid license after a trial. I left off the ![paid] badge since the app and source are free to use, but happy to add it if you prefer.
