### PR TITLE
Add Margin to Office & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Handwriting keyboard](https://github.com/BigIskander/Handwriting-keyboard-for-Linux-tesseract) - Handwriting keyboard for Linux X11 desktop environment.
 - [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable, offline-first Markdown editor. Single exe, no install, zero telemetry.
 - [JournalV](https://github.com/ahmedkapro/journalv) - Journaling app for your days and dreams.
+- [Margin](https://github.com/K1ta141k/margin) ![v2] - In-place AI editor for PDF, LaTeX, and Markdown with live preview and source-linked citations.
 - [MarkFlowy](https://github.com/drl990114/MarkFlowy) - Modern markdown editor application with built-in ChatGPT extension.
 - [MD Viewer](https://github.com/kuyoonjo/md-viewer) - Cross-platform markdown viewer.
 - [MDX Notes](https://github.com/maqi1520/mdx-notes/tree/tauri-app) - Versatile WeChat typesetting editor and cross-platform Markdown note-taking software.


### PR DESCRIPTION
This is the link to the project: [Margin](https://github.com/K1ta141k/margin)

Adds Margin, an open-source Tauri v2 desktop app, to **Applications → Office & Writing** (alphabetically).

- [x] I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).
- [x] Use the following format: `[Title](link) - Description.`
- [x] If the project uses Tauri **v2** add the `![v2]` badge (added).
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [x] I have signed my commits (GitHub-verified).

### Apps

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure.
