### PR TITLE
Add Reado to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Ngroker](https://ngroker.com) ![closed source] ![paid] - 🆖ngrok gui client.
 - [Soda](https://github.com/Web3-Builders-Alliance/soda) - Generate source code from an IDL.
 - [Pake](https://github.com/tw93/Pake) - Turn any webpage into a desktop app with Rust with ease.
+- [Reado](https://github.com/WatermelonBros/reado) ![v2] - Read-first code IDE for the AI era; you review changes and leave durable anchored comments while the agent commits.
 - [Rivet](https://github.com/Ironclad/rivet) - Visual programming environment for creating AI features and agents.
 - [TableX](https://tablex-tan.vercel.app/) - Table viewer for modern developers
 - [TangleGuard](https://tangleguard.com) ![closed source] - A software architecture monitoring tool 


### PR DESCRIPTION
Adding Reado, an open-source read-first code IDE built with Tauri 2, to the Developer tools section.

- Repo: https://github.com/WatermelonBros/reado
- Site: https://reado.watermelon-studio.it

Checklist:
- [x] Format `[Title](link) - Description.`
- [x] Added alphabetically to the most appropriate category (Developer tools)
- [x] Description under 24 words, no links/parenthesis, doesn't start with A/An
- [x] Open source
- [x] One suggestion per pull request