### PR TITLE
Add Praxia Desktop to Applications > Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [PasteBar](https://github.com/PasteBar/PasteBarApp) - Limitless, Free Clipboard Manager for Mac and Windows. Effortless management of everything you copy and paste.
 - [PicSharp](https://github.com/AkiraBit/PicSharp) ![v2] - With powerful and richly configured compression functions, it helps you easily optimize images, providing outstanding performance and a convenient operation experience.
 - [Pomodoro](https://github.com/g07cha/pomodoro) - Time management tool based on Pomodoro technique.
+- [Praxia Desktop](https://github.com/praxia-dev/praxia) ![v2] - Local-first AI workspace where chat schedules cron jobs, fans out parallel batches across files, and generates editable native .pptx. Tauri 2 + Python (PyInstaller) sidecar; Apache 2.0; free on Microsoft Store.
 - [Progressive](https://github.com/h8moss/progressive)![v2] - Todo app with progress tracking. Supports task weighting, percentage completion, and parent/child tasks.
 - [Qopy](https://github.com/0PandaDEV/Qopy) - The fixed Clipboard Manager for Windows and Mac.
 - [Remind Me Again](https://github.com/probablykasper/remind-me-again) - Toggleable reminders app for Mac, Linux and Windows.

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [PasteBar](https://github.com/PasteBar/PasteBarApp) - Limitless, Free Clipboard Manager for Mac and Windows. Effortless management of everything you copy and paste.
 - [PicSharp](https://github.com/AkiraBit/PicSharp) ![v2] - With powerful and richly configured compression functions, it helps you easily optimize images, providing outstanding performance and a convenient operation experience.
 - [Pomodoro](https://github.com/g07cha/pomodoro) - Time management tool based on Pomodoro technique.
-- [Praxia Desktop](https://github.com/praxia-dev/praxia) ![v2] - Local-first AI workspace where chat schedules cron jobs, fans out parallel batches across files, and generates editable native .pptx. Tauri 2 + Python (PyInstaller) sidecar; Apache 2.0; free on Microsoft Store.
+- [Praxia Desktop](https://github.com/praxia-dev/praxia) ![v2] - Local-first AI workspace that turns chat into cron jobs, parallel batches, and editable `.pptx`.
 - [Progressive](https://github.com/h8moss/progressive)![v2] - Todo app with progress tracking. Supports task weighting, percentage completion, and parent/child tasks.
 - [Qopy](https://github.com/0PandaDEV/Qopy) - The fixed Clipboard Manager for Windows and Mac.
 - [Remind Me Again](https://github.com/probablykasper/remind-me-again) - Toggleable reminders app for Mac, Linux and Windows.


### PR DESCRIPTION
This is the link to the project: [Praxia Desktop](https://github.com/praxia-dev/praxia)

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [ ] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
- [ ] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
- [ ] If the project/article uses Tauri **v1** add the `![v1]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v2** add the `![v2]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [ ] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional).

### Plugins/Integrations

<!-- N/A — this is an app, not a plugin -->

### Templates

<!-- N/A — this is an app, not a template -->

### Apps

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure.
- [ ] If the app is closed source, evidence of it being built with Tauri is included.

### Additional Context

Praxia Desktop is a local-first AI workspace for Windows: chat drives scheduled jobs, parallel batches over files, and editable native `.pptx` rendering. Available free on the Microsoft Store and source-available under Apache 2.0.

Tauri 2 specifics (in case useful for review):
- Tauri 2 shell + PyInstaller-frozen Python sidecar (FastAPI + LiteLLM)
- Spawned via `Command::new(...).spawn()`, torn down on `RunEvent::Exit` via a drop-guard wrapper
- IPC over `http://ipc.localhost` with CSP `connect-src` extended for `ipc:`
- MSIX packaging with `runFullTrust` capability declared and justified; passed Microsoft Store certification on the first submission
- Repository age: well over 30 days, active development; demo at https://youtu.be/Z3DFa2saHJg

Inserted between `Pomodoro` and `Progressive` to preserve the alphabetical ordering of the `Applications > Productivity` subsection.