### PR TITLE
Add Libre Academy to Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 ### Learning
 
 - [Japanese](https://github.com/meel-hd/japanese) - Learn Japanese Hiragana and Katakana. Memorize, write, pronounce, and test your knowledge.
+- [Libre Academy](https://github.com/InfamousVague/Libre.academy) ![v2] - Learn to code by writing real code across 90+ interactive courses in 26 languages, graded instantly by hidden test suites.
 - [Manjaro Starter](https://github.com/oguzkaganeren/manjaro-starter) - Documentation and support app for new Manjaro users.
 - [Piano Trainer](https://github.com/ZaneH/piano-trainer) - Practice piano chords, scales, and more using your MIDI keyboard.
 - [Solars](https://github.com/hiltontj/solars) - Visualize the planets of our solar system.


### PR DESCRIPTION
Adds [Libre Academy](https://github.com/InfamousVague/Libre.academy) to **Applications → Learning**, in alphabetical order.

Libre Academy is an open-source (MIT) Tauri v2 app for learning to code: learners write real code across 90+ interactive courses spanning 26 languages, graded instantly by hidden test suites. It ships as a signed desktop app (macOS/Windows/Linux) and a web app.

- Built with **Tauri v2** (`![v2]` badge applied).
- Open source: https://github.com/InfamousVague/Libre.academy (MIT licensed).
- Website: https://libre.academy
- Placed alphabetically within the Learning section.