### PR TITLE
Add OpenTypeless

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Mr Tagger](https://github.com/probablykasper/mr-tagger) - Music file tagging app.
 - [Musicat](https://github.com/basharovV/musicat) - Sleek desktop music player and tagger for offline music.
 - [NeoDLP](https://github.com/neosubhamoy/neodlp) ![v2] - Modern video/audio downloader based on `yt-dlp` with browser integration.
+- [OpenTypeless](https://github.com/tover0314-w/opentypeless) ![v2] - Cross-platform AI voice input, rewriting, and voice Q&A app that types polished text into any app.
 - [PunyTunes](https://github.com/mjoblin/punytunes) ![v1] - Control StreamMagic music streamers from the system tray.
 - [Screenpipe](https://github.com/screenpipe/screenpipe) - 24/7 local AI screen & mic recording. Build AI apps with full context. Works with Ollama.
 - [SilentKeys](https://github.com/gptguy/silentkeys) ![v2] - Privacy-first, real-time dictation app built with Tauri, powered by `Parakeet ASR`, `Silero-VAD`, and on-device inference via `ORT`.


### PR DESCRIPTION
Adds OpenTypeless to Applications > Audio & Video.\n\nOpenTypeless is an open-source Tauri v2 desktop app for AI voice input, rewriting, and voice Q&A across macOS, Windows, and Linux.