### PR TITLE
Add MoonProxy to Networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Jexpe](https://github.com/jexpe-apps/jexpe) - Cross-platform, open source SSH and SFTP client that makes connecting to your remote servers easy.
 - [Mail-Dev](https://github.com/samirdjelal/mail-dev) - Cross-platform, local SMTP server for email testing/debugging.
 - [mDNS-Browser](https://github.com/hrzlgnm/mdns-browser) - Cross-platform mDNS browser app for discovering network services using mDNS.
+- [MoonProxy](https://github.com/MoonProxyHQ/moonproxy-desktop) ![v2] - Cross-platform desktop GUI client for FRP (frpc) — turn intranet exposure into one click.
 - [NetDia](https://github.com/shellrow/netdia) ![v2] - Cross-platform network diagnostic tool for inspecting, monitoring, and analyzing your network.
 - [Nhex](https://github.com/nhexirc/nhex) - Next-generation IRC client inspired by HexChat.
 - [RustDesk](https://github.com/rustdesk/rustdesk-server) - Self-hosted server for RustDesk, an open source remote desktop.


### PR DESCRIPTION
Adds **MoonProxy (月神代理)** to the **Networking** section, alphabetically between `mDNS-Browser` and `NetDia`.

## Why it belongs here

MoonProxy is a **Tauri v2** desktop GUI client for **FRP** (`fatedier/frp`). It exposes local TCP/UDP/HTTP/HTTPS services to the public internet through a graphical interface — no command line, no config files. Built with **Tauri v2 + Vue 3 + Rust + TypeScript**, MIT licensed, **macOS & Windows**.

The entry carries the `![v2]` badge consistent with the other v2 apps in the section (EasyTier, NetDia, etc.).

## What it does (one line)

Turns intranet exposure into a single button — publishes your local ERP, NAS, Minecraft server, or self-built site to the public web in one click.

## Compliance with the list

- ✅ Single line, `- [Name](URL) ![v2] - description.` format, matching the section's existing entries
- ✅ Placed in alphabetical order (MoonProxy → between mDNS-Browser and NetDia)
- ✅ Description starts with a capitalized noun phrase, ends with no period (matches house style)
- ✅ Open source, MIT, has a real website (moonproxy.app) and GitHub repo

## Independence disclosure

MoonProxy is **independent of** `fatedier/frp`. It is only a GUI desktop client; the frpc binary is bundled via the Tauri sidecar mechanism. This is documented in the project README.

## Links

- Site: https://moonproxy.app
- Repo: https://github.com/MoonProxyHQ/moonproxy-desktop
- License: MIT
- Latest release: https://github.com/MoonProxyHQ/moonproxy-desktop/releases/latest