### PR TITLE
Add GitWand to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [GitButler](https://gitbutler.com) - GitButler is a new Source Code Management system.
 - [Github Security Alerts](https://github.com/stephanebouget/github-security-alerts) ![v2] - Monitors security vulnerabilities across your GitHub repositories in real-time.
 - [GitLight](https://github.com/colinlienard/gitlight) - GitHub & GitLab notifications on your desktop.
+- [GitWand](https://github.com/devlint/GitWand) ![v2] - Git client that auto-resolves trivial merge conflicts with deterministic patterns, with PR review and AI agent sessions.
 - [JET Pilot](https://www.jet-pilot.app) - Kubernetes desktop client that focuses on less clutter, speed and good looks.
 - [Hoppscotch](https://hoppscotch.com/download) ![closed source] - Trusted by millions of developers to build, test and share APIs.
 - [Keadex Mina](https://github.com/keadex/keadex) - Open Source, serverless IDE to easily code and organize at a scale C4 model diagrams.


### PR DESCRIPTION
Adds [GitWand](https://github.com/devlint/GitWand) to Applications → Developer tools — a free, open-source (MIT) Tauri 2 + Rust Git client that auto-resolves trivial merge conflicts with a deterministic pattern engine (confidence scores, full decision trace), plus in-app PR review (GitHub/GitLab/Bitbucket/Azure) and AI agent sessions. Inserted in alphabetical order with the ![v2] badge. Disclosure: I'm the author.