### PR TITLE
Add clipygo to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [TypeView - KeyStroke Visualizer](https://github.com/dunkbing/typeview) - Visualizes keys pressed on the screen and simulates the sound of mechanical keyboard.
 - [Browsernaut](https://github.com/billyjacoby/browsernaut) - Browser picker for macOS.
 - [Clipboard Record](https://github.com/lesterhnu/clipboard) - Record Clipboard Content.
+- [clipygo](https://github.com/it-atelier-gn/clipygo) ![v2] - Clipboard monitor that matches patterns via regex and routes content to plugin-based targets.
 - [CrabCamera](https://github.com/Michael-A-Kuykendall/crabcamera) - Professional desktop camera plugin for Tauri applications with WebRTC streaming and advanced hardware controls.
 - [DecentPaste](https://github.com/decentpaste/decentpaste) ![v2] - Cross-platform clipboard sharing over local network with P2P encryption.
 - [Dwall](https://github.com/dwall-rs/dwall) - Change the Windows desktop and lock screen wallpapers according to the sun's azimuth and altitude angles, just like on macOS.


### PR DESCRIPTION
This is the link to the project: [clipygo](https://github.com/it-atelier-gn/clipygo)

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [ ] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
- [ ] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
- [ ] If the project/article uses Tauri **v1** add the `![v1]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v2** add the `![v2]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [ ] I have signed my commits (optional).

### Apps

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure.
- [ ] If the app is closed source, evidence of it being built with Tauri is included.

### Additional Context

clipygo is a Tauri 2 + SvelteKit clipboard monitor with a plugin system (subprocess-based, JSON protocol over stdin/stdout) for routing matched clipboard content to targets like Teams, Discord, Telegram, Obsidian, and an E2E-encrypted relay. Adding it to Utilities alongside the other clipboard tools already listed there.