### PR TITLE
Add Kotodama to ChatGPT clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [ChatGPT-Desktop](https://github.com/Synaptrix/ChatGPT-Desktop) - Cross-platform productivity ChatGPT assistant launcher.
 - [Jan](https://github.com/menloresearch/jan) ![v2] - Open source alternative to ChatGPT that runs 100% offline on your computer.
 - [Kaas](https://github.com/0xfrankz/Kaas) - Cross-platform desktop LLM client for OpenAI ChatGPT, Anthropic Claude, Microsoft Azure and more, with a focus on privacy and security.
+- [Kotodama](https://github.com/Michel-IT/Kotodama) - All your AI assistants in one desktop window, with auto-send prompts. Fully local, no backend, no telemetry.
 - [Nexo](https://github.com/Nexo-Agent/nexo) - All-in-One Workspace AI
 - [Orion](https://github.com/taecontrol/orion) - Cross-platform app that lets you create multiple AI assistants with specific goals powered with ChatGPT.
 - [Oxide-Lab](https://github.com/FerrisMind/oxide-lab) ![v2] - Local LLM chat application with privacy-focused AI inference using `candle` and Rust backend.


### PR DESCRIPTION
Adding [Kotodama](https://github.com/Michel-IT/Kotodama), a Tauri + Rust desktop app that puts all AI assistants (ChatGPT, Claude, Gemini, Copilot, Perplexity, etc.) in one window with auto-send prompts. Fully local, no backend, no telemetry, open source.

Fits the ChatGPT clients section as a multi-LLM desktop client built with Tauri.