### PR TITLE
Add CloakGuard to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Authme](https://github.com/Levminer/authme) - Two-factor (2FA) authentication app for desktop.
 - [Calciumdibromid](https://codeberg.org/Calciumdibromid/CaBr2) - Generate "experiment wise safety sheets" in compliance to European law.
 - [chiffrage](https://github.com/thrzl/chiffrage) ![v2] - Cross-platform UI for encrypting files and text with the age encryption format.
+- [CloakGuard](https://github.com/benthompsondev/cloakguard) ![v2] - Local-first tool to find and redact secrets, credentials, and personal data in text before you share it. Runs offline, with a browser demo.
 - [Defguard](https://github.com/defguard/client) - WireGuard VPN destkop client with Two-factor (2FA) authentication.
 - [Gluhny](https://github.com/angeldollface/gluhny) A graphical interface to validate IMEI numbers.
 - [JumpServer](https://github.com/jumpserver/client/) ![v2] - Open-source PAM client, modern, beautiful, and natively consistent.


### PR DESCRIPTION
Adding CloakGuard to the Security section.

CloakGuard is a local-first tool for finding and redacting secrets, credentials, infrastructure details, and personal data in text before you share it — code, logs, prompts, support tickets, or draft posts. Scanning runs entirely on device with no backend, account, or telemetry.

- Repo: https://github.com/benthompsondev/cloakguard
- Live browser demo: https://benthompsondev.github.io/cloakguard/
- Built with Tauri v2, cross-platform (Windows and Linux) with a signed updater, MIT licensed.

Entry placed alphabetically in the Security section.