### PR TITLE
Add Ghost Vessel to ChatGPT clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 
 - [ChatGPT](https://github.com/lencx/ChatGPT) - Cross-platform ChatGPT desktop application.
 - [ChatGPT-Desktop](https://github.com/Synaptrix/ChatGPT-Desktop) - Cross-platform productivity ChatGPT assistant launcher.
+- [Ghost Vessel](https://github.com/ghdtjrtka/ghost-vessel) ![v2] - Monitor-resident avatar frontend for a local LLM agent, with emotion-beat expressions played from pre-rendered clips, a persistent mood system, and local TTS/STT.
 - [Jan](https://github.com/menloresearch/jan) ![v2] - Open source alternative to ChatGPT that runs 100% offline on your computer.
 - [Kaas](https://github.com/0xfrankz/Kaas) - Cross-platform desktop LLM client for OpenAI ChatGPT, Anthropic Claude, Microsoft Azure and more, with a focus on privacy and security.
 - [Nexo](https://github.com/Nexo-Agent/nexo) - All-in-One Workspace AI


### PR DESCRIPTION
Adds **Ghost Vessel** to *Applications → ChatGPT clients*, alphabetically between ChatGPT-Desktop and Jan.

[ghdtjrtka/ghost-vessel](https://github.com/ghdtjrtka/ghost-vessel) is a Tauri **v2** desktop app (frameless, transparent, always-on-top): a monitor-resident, video-call-style avatar that fronts a local LLM agent. The agent's replies drive facial emotion beats played from pre-rendered clips, with a persistent mood system and local TTS out / VAD+STT in. MIT engine.

Sits alongside the other local-LLM clients in this category (Jan, Kaas, Oxide-Lab). Tagged `![v2]`. Happy to move it if you'd prefer a different category.