### PR TITLE
Add tauri-plugin-auth-session

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-plugin-android-fs](https://github.com/aiueo13/tauri-plugin-android-fs) ![v2] - Access the file system on Android.
 - [tauri-plugin-aptabase](https://github.com/aptabase/tauri-plugin-aptabase) - Privacy-first and minimalist analytics for desktop and mobile apps.
 - [tauri-plugin-auth](https://github.com/inKibra/tauri-plugins/tree/main/packages/tauri-plugin-auth) - Auth plugin for iOS that uses ASWebAuthenticationSession for authentication, which allows keychain access
+- [tauri-plugin-auth-session](https://github.com/yanqianglu/tauri-plugin-auth-session) ![v2] - In-app OAuth and OIDC on iOS, macOS, and Android using ASWebAuthenticationSession and Chrome Custom Tabs, with PKCE support.
 - [tauri-plugin-blec](https://github.com/MnlPhlp/tauri-plugin-blec) - Cross platform Bluetooth Low Energy client based on `btleplug`.
 - [tauri-plugin-cache](https://github.com/Taiizor/tauri-plugin-cache) - Advanced disk caching solution with memory layer, TTL management, compression support, and cross-platform compatibility for desktop and mobile.
 - [tauri-plugin-clipboard](https://github.com/CrossCopy/tauri-plugin-clipboard) - Clipboard plugin for reading/writing clipboard text/image/html/rtf/files, and monitoring clipboard update.


### PR DESCRIPTION
This is the link to the project: [tauri-plugin-auth-session](https://github.com/yanqianglu/tauri-plugin-auth-session)

It does browser-based OAuth and OIDC on mobile and desktop. On iOS and macOS it uses ASWebAuthenticationSession; on Android, Chrome Custom Tabs. Login runs in the real system browser instead of a webview, and the redirect comes back through a custom URL scheme. There is already a `tauri-plugin-auth` entry in the list, but it only covers iOS. This one works the same way across iOS, macOS, and Android with a single `start()` call. Licensed MIT or Apache-2.0.

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [ ] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
- [ ] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
- [ ] If the project/article uses Tauri **v1** add the `![v1]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v2** add the `![v2]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [ ] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional).

### Plugins/Integrations

- [x] Works with **Tauri 2.x or later**.
- [x] The project is open source and accepts contributions.
- [x] The repo is at least 30 days old.
- [x] Documentation is in English.
- [x] The project is active and maintained.
