### PR TITLE
Add tauri-plugin-mobile-push

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-plugin-js](https://github.com/HuakunShen/tauri-plugin-js) ![v2] - Give your app Electron-like JS backends with type-safe RPC powered by `kkrpc`. Supports Bun, Node.js, and Deno.
 - [tauri-plugin-keep-screen-on](https://gitlab.com/cristofa/tauri-plugin-keep-screen-on) - Disable screen timeout on Android and iOS.
 - [tauri-plugin-macos-permissions](https://github.com/ayangweb/tauri-plugin-macos-permissions) - Support for checking and requesting macOS system permissions.
+- [tauri-plugin-mobile-push](https://github.com/yanqianglu/tauri-plugin-mobile-push) ![v2] - Remote push notifications on iOS and Android via APNs and FCM, with zero-config iOS setup and no method swizzling.
 - [tauri-plugin-mobile-sharetarget](https://github.com/IT-ess/tauri-plugin-mobile-sharetarget) ![v2] - Handle mobile Share Intents with a FIFO queue
 - [tauri-plugin-mqtt](https://github.com/kuyoonjo/tauri-plugin-mqtt) - MQTT client support.
 - [tauri-plugin-network](https://github.com/HuakunShen/tauri-plugin-network) - Tools for reading network information and scanning network.


### PR DESCRIPTION
This is the link to the project: [tauri-plugin-mobile-push](https://github.com/yanqianglu/tauri-plugin-mobile-push)

It handles real server-sent push notifications on mobile: APNs on iOS and FCM on Android. The official notification plugin only does local notifications, so there is a gap here for anyone who needs to send pushes from a backend. The iOS side is worth calling out: it needs no `AppDelegate.swift` and does not use method swizzling. It injects the APNs delegate methods at runtime through `@_cdecl` FFI, so it will not clash with other plugins that touch the app delegate. Licensed MIT or Apache-2.0.

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [ ] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
- [ ] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
- [ ] If the project/article uses Tauri **v1** add the `![v1]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v2** add the `![v2]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [ ] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional).

### Plugins/Integrations

- [x] Works with **Tauri 2.x or later**.
- [x] The project is open source and accepts contributions.
- [x] The repo is at least 30 days old.
- [x] Documentation is in English.
- [x] The project is active and maintained.
