### PR TITLE
Add Tokibean to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [TangleGuard](https://tangleguard.com) ![closed source] - A software architecture monitoring tool 
 - [Tauri Mobile Test](https://github.com/dedSyn4ps3/tauri-mobile-test) - Create and build cross-platform mobile applications.
 - [Testfully](https://testfully.io/) ![closed source] ![paid] - Offline API Client & Testing tool.
+- [Tokibean](https://github.com/ZGhey/tokibean) ![v2] - Desktop pet that mirrors what Claude Code is doing and tracks token usage against the official Anthropic 5-hour window.
 - [verbcode](https://github.com/Verbcode/verbcode-release) ![closed source] - Simplify your localization journey.
 - [Worktree Status](https://github.com/sandercox/worktree-status/) - Get git repo status in your macOS MenuBar or Windows notification area.
 - [Yaak](https://yaak.app) - Organize and execute REST, GraphQL, and gRPC requests.


### PR DESCRIPTION
Adds [Tokibean](https://github.com/ZGhey/tokibean) to **Applications → Developer tools**.

- [Tokibean](https://github.com/ZGhey/tokibean) ![v2] - Desktop pet that mirrors what Claude Code is doing and tracks token usage against the official Anthropic 5-hour window.

Tauri 2, open source (MIT), builds for macOS / Windows / Linux. Transparent always-on-top pixel mascot driven by Claude Code hook events, plus a usage panel fed by the official Anthropic usage API.

Checklist:
- [x] Format `[Title](link) - Description.`
- [x] Added alphabetically to the most appropriate category
- [x] Description under 24 words, no links, no parenthesis, does not start with `A`/`An`
- [x] Open source and accepting contributions
- [x] README in English
- [x] One suggestion in this pull request