### PR TITLE
Add eVi

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 
 - [ChatGPT](https://github.com/lencx/ChatGPT) - Cross-platform ChatGPT desktop application.
 - [ChatGPT-Desktop](https://github.com/Synaptrix/ChatGPT-Desktop) - Cross-platform productivity ChatGPT assistant launcher.
+- [eVi](https://github.com/evi-assistant/evi-ai) ![v2] - Local-first personal assistant that runs open-weight LLMs on your own hardware via `Ollama`, `LM Studio`, or `llama.cpp`, with tools, memory, and MCP client.
 - [Jan](https://github.com/menloresearch/jan) ![v2] - Open source alternative to ChatGPT that runs 100% offline on your computer.
 - [Kaas](https://github.com/0xfrankz/Kaas) - Cross-platform desktop LLM client for OpenAI ChatGPT, Anthropic Claude, Microsoft Azure and more, with a focus on privacy and security.
 - [Nexo](https://github.com/Nexo-Agent/nexo) - All-in-One Workspace AI


### PR DESCRIPTION
Adds **eVi** to Applications → ChatGPT clients (placed alphabetically between ChatGPT-Desktop and Jan).

eVi is a local-first personal AI assistant whose native desktop app is built with Tauri 2. It runs open-weight LLMs on the user's own hardware (Ollama, LM Studio, llama.cpp, or any OpenAI-compatible endpoint), with tools, long-term memory, and MCP-client support, across CLI/web/desktop.

- Repo: https://github.com/evi-assistant/evi-ai (MIT)
- Homepage: https://evi-ai.dev

Disclosure: I'm the maintainer of eVi. Single entry, added alphabetically; `![v2]` badge since the shell is Tauri 2.x.