### PR TITLE
Add Arf to Office & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 
 ### Office & Writing
 
+- [Arf](https://github.com/tunabirgun/arf) ![v2] - Local-first second brain for scientists and coders: plain-Markdown notes with wikilinks, LaTeX and code, a knowledge graph, and on-device embeddings that surface related but unlinked notes.
 - [Astro Editor](https://github.com/dannysmith/astro-editor) - Clean markdown editor for Astro content collections with frontmatter editing, component insertion, and writing-focused interface.
 - [fylepad](https://github.com/imrofayel/fylepad/) - Notepad with powerful rich-text editing, built with Vue & Tauri.
 - [Bidirectional](https://github.com/samirdjelal/bidirectional) - Write Arabic text in apps that don't support bidirectional text.


### PR DESCRIPTION
Adds **Arf** to **Applications → Office & Writing**.

Arf is a local-first second brain for scientists and coders, built with **Tauri v2** (Svelte + Rust) for Windows, macOS, and Linux: plain-Markdown notes with `[[wikilinks]]`, LaTeX and syntax-highlighted code, a knowledge graph, and on-device MiniLM embeddings that surface related but unlinked notes. All data stays local. It sits naturally next to Blinko and Fluster in this section.

Repo: https://github.com/tunabirgun/arf · Releases: https://github.com/tunabirgun/arf/releases/latest

Placed alphabetically and tagged `![v2]`. Disclosure: I'm the author.