### PR TITLE
Add YAKC (keystroke visualizer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Vibe](https://thewh1teagle.github.io/vibe) - Transcribe audio or video in every language on every platform.
 - [Wallpaper changer](https://github.com/zeet2020/wallpaper-changer-tauri) - Simple wallpaper changer app.
 - [WSL UI](https://github.com/octasoft-ltd/wsl-ui) ![v2] - A lightweight desktop application for managing WSL distributions on Windows.
+- [YAKC (Yet Another Key Caster)](https://github.com/iammodev/YAKC) ![v2] - Cross-platform keystroke & mouse-click visualizer for screencasts, streaming, and presentations; works on Windows, macOS, and Linux (X11 & Wayland).
 - [Zap](https://usezap.sh/?ref=awesometauri) ![closed source] - macOS spotlight-like dock that makes navigating apps convenient.
 - [Zapicon](https://zapicon.once.work/en) ![closed source] ![paid] ![v2] - Cross-platform icon generator with visual editing, iOS squircle, theme presets, design guidelines, and one-click multi-platform export.
 


### PR DESCRIPTION
Adds **YAKC (Yet Another Key Caster)** to Applications → Utilities.

YAKC is a Tauri 2 + Rust **keystroke & mouse-click visualizer** that shows on-screen popups for screencasts, streaming and presentations. It runs on **Windows, macOS and Linux (X11 and Wayland)** and displays any keyboard language automatically.

- Repo: https://github.com/iammodev/YAKC
- Latest release with installers for all platforms: https://github.com/iammodev/YAKC/releases/latest

Entry follows the existing format (alphabetical, `![v2]` badge, single-line description).