### PR TITLE
Add Chaty to ChatGPT clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 
 - [ChatGPT](https://github.com/lencx/ChatGPT) - Cross-platform ChatGPT desktop application.
 - [ChatGPT-Desktop](https://github.com/Synaptrix/ChatGPT-Desktop) - Cross-platform productivity ChatGPT assistant launcher.
+- [Chaty](https://github.com/Fangyuan025/Chaty) ![v2] - Local, private desktop AI for GGUF and native MLX models — chat, RAG, vision, voice, and an agentic coding mode, fully offline.
 - [Jan](https://github.com/menloresearch/jan) ![v2] - Open source alternative to ChatGPT that runs 100% offline on your computer.
 - [Kaas](https://github.com/0xfrankz/Kaas) - Cross-platform desktop LLM client for OpenAI ChatGPT, Anthropic Claude, Microsoft Azure and more, with a focus on privacy and security.
 - [Nexo](https://github.com/Nexo-Agent/nexo) - All-in-One Workspace AI


### PR DESCRIPTION
Adds **Chaty** to the ChatGPT clients section (alphabetical order, `![v2]` badge).

Chaty is an MIT-licensed Tauri 2 desktop app for running LLMs fully locally — GGUF models (Windows/Vulkan, macOS/Metal) plus native MLX models on Apple Silicon via a process-isolated Swift sidecar. Chat, document RAG with citations, vision, voice, and a sandboxed agentic coding mode. No API keys, nothing leaves the machine.

- Repo: https://github.com/Fangyuan025/Chaty
- Site: https://chaty.ca