### PR TITLE
Add WidgetSpark (Utilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Verve](https://github.com/ParthJadhav/verve) - Launcher for accessing and opening applications, files and documents.
 - [Vibe](https://thewh1teagle.github.io/vibe) - Transcribe audio or video in every language on every platform.
 - [Wallpaper changer](https://github.com/zeet2020/wallpaper-changer-tauri) - Simple wallpaper changer app.
+- [WidgetSpark](https://widgetspark.com) ![closed source] - Live desktop widgets for Windows — weather, system stats, clocks, countdowns and more, in light or dark, pinnable on top.
 - [WSL UI](https://github.com/octasoft-ltd/wsl-ui) ![v2] - A lightweight desktop application for managing WSL distributions on Windows.
 - [Zap](https://usezap.sh/?ref=awesometauri) ![closed source] - macOS spotlight-like dock that makes navigating apps convenient.
 - [Zapicon](https://zapicon.once.work/en) ![closed source] ![paid] ![v2] - Cross-platform icon generator with visual editing, iOS squircle, theme presets, design guidelines, and one-click multi-platform export.


### PR DESCRIPTION
Adds [WidgetSpark](https://widgetspark.com) — live desktop widgets for Windows (weather, system stats, clocks, countdowns and more), built on Tauri 2. Closed source, badged accordingly; free tier with paid plans. On the [Microsoft Store](https://apps.microsoft.com/detail/9PMGHCPJRL43).

Entry placed alphabetically in Applications › Utilities.

(Disclosure: I'm the developer.)