### PR TITLE
Add Fletch to Applications > Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Docker DB Manager](https://github.com/AbianS/docker-db-manager) ![v2] - Desktop app for managing Docker database containers with visual interface, data persistence, and one-click connection strings.
 - [Dropcode](https://github.com/egoist/dropcode) - Simple and lightweight code snippet manager.
 - [Echoo](https://github.com/zsmatrix62/echoo-app) - Offline/Online utilities for developers on MacOS & Windows.
+- [Fletch](https://fletch.sh) ![v2] - Runs AI coding agents in sandboxed macOS workspaces, each with its own repo clone, code index, and diff review before merge.
 - [GitButler](https://gitbutler.com) - GitButler is a new Source Code Management system.
 - [Github Security Alerts](https://github.com/stephanebouget/github-security-alerts) ![v2] - Monitors security vulnerabilities across your GitHub repositories in real-time.
 - [GitLight](https://github.com/colinlienard/gitlight) - GitHub & GitLab notifications on your desktop.


### PR DESCRIPTION
Adds [Fletch](https://fletch.sh) to **Applications > Developer tools**.

Fletch is a native macOS IDE for running AI coding agents (Claude Code, Codex, Cursor Agent, OpenCode) on real work. Each agent gets its own clone of the repository with its own writable `.git`, sealed in a macOS Seatbelt sandbox or its own Docker container, so the user's working copy is never writable by an agent. A symbol and call-graph index of the repo is served to every agent over MCP, and diffs are reviewed before anything merges.

Built with Tauri 2 and a Rust backend. 18 MB universal binary, signed and notarized, self-updating. Free and open source under AGPL-3.0: https://github.com/fwdai/fletch

Checked against the contribution guidelines:

- [x] Format is `[Title](link) - Description.`
- [x] `![v2]` badge included, after the link and before the dash, since it targets Tauri 2
- [x] Added alphabetically, between Echoo and GitButler
- [x] Description does not start with "A" or "An"
- [x] Description is 21 words, under the 24 word limit
- [x] Description contains no links and no parentheses
- [x] No trailing whitespace added
- [x] One suggestion in this pull request
- [x] Commit is signed
- [x] Open source and accepts contributions, README in English

Not marked closed source or paid, since it is free and AGPL-3.0.