### PR TITLE
Add Foglio

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Curses](https://github.com/mmpneo/curses) - Speech-to-Text and Text-to-Speech captions for OBS, VRChat, Twitch chat and more.
 - [Douyin Downloader](https://github.com/lzdyes/douyin-downloader) - Cross-platform douyin video downloader.
 - [Feiyu Player](https://github.com/idootop/feiyu-player) - Cross-platform online video player where beauty meets functionality.
+- [Foglio](https://github.com/fran-mora/foglio) ![v2] - Markdown editor for macOS that renders inline as you type and saves files byte for byte, without reformatting.
 - [Global Hotkey Spotify](https://github.com/Sid-V/global_hotkey_spotify) ![v2] - Control Spotify playback with custom global keyboard shortcuts, no media keys needed.
 - [Hopp](https://github.com/gethopp/hopp) ![v2] - Open source remote pair programming app.
 - [Hypetrigger](https://hypetrigger.io/) ![closed source] - Detect highlight clips in video with FFMPEG + Tensorflow on the GPU.


### PR DESCRIPTION
Foglio is an open-source Markdown editor for macOS built with Tauri 2 and CodeMirror 6. Markdown renders in place as you type, and the raw syntax returns on whichever line holds the cursor.

https://github.com/fran-mora/foglio

- [x] Works with Tauri 1.x and onward — built on Tauri 2
- [x] The project is open source and accepts contributions — MIT
- [x] Added alphabetically to the Applications category
- [x] Description is 17 words, no links or parenthesis, does not start with A or An
- [x] No trailing whitespace
- [x] One suggestion per pull request
- [x] I have signed my commits