### PR TITLE
Add RepoPuck

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Ngroker](https://ngroker.com) ![closed source] ![paid] - 🆖ngrok gui client.
 - [Soda](https://github.com/Web3-Builders-Alliance/soda) - Generate source code from an IDL.
 - [Pake](https://github.com/tw93/Pake) - Turn any webpage into a desktop app with Rust with ease.
+- [RepoPuck](https://github.com/YYchainsAw/RepoPuck) ![v2] - Lightweight Windows Git companion for staging, committing, and pushing from an always-ready desktop panel.
 - [Rivet](https://github.com/Ironclad/rivet) - Visual programming environment for creating AI features and agents.
 - [TableX](https://tablex-tan.vercel.app/) - Table viewer for modern developers
 - [TangleGuard](https://tangleguard.com) ![closed source] - A software architecture monitoring tool 


### PR DESCRIPTION
This is the link to the project: [RepoPuck](https://github.com/YYchainsAw/RepoPuck)

- [x] **I have read the contributing guidelines.**
- [x] Uses the required `[Title](link) - Description.` format.
- [x] Closed-source badge is not applicable; RepoPuck is MIT-licensed and open source.
- [x] Paid badge is not applicable; RepoPuck is free.
- [x] Includes the Tauri `![v2]` badge.
- [x] Added alphabetically to Applications → Developer tools, between Pake and Rivet.
- [x] Avoids unnecessary wording.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parentheses.
- [x] Package-name backticks are not applicable.
- [x] Spelling and grammar were checked.
- [x] No trailing whitespace was added.
- [x] This pull request contains one suggestion.
- [x] I understand that the entry can be removed if it violates the guidelines.
- [x] The commit is cryptographically signed and shown as verified by GitHub.

### Apps

- [x] The app is original and not too simple.
- [x] The README is available in English.
- [x] The app documents its lightweight architecture and security boundaries.
- [x] Closed-source Tauri evidence is not applicable.

### Additional Context

RepoPuck is a Windows-first Git companion built with Tauri 2 and Rust. Its English documentation, MIT-licensed source, Windows release assets, checksums, and build provenance are public in the repository.