### PR TITLE
Add Tauri v2 updater guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Create Tauri App with React](https://www.youtube.com/watch?v=zawhqLA7N9Y&ab_channel=chrisbiscardi) ![youtube] - Chris Biscardi shows how easy it is to wire up a Rust crate with a JS module and communicate between them.
 - [Publish to Apple's App Store](https://thinkgo.io/post/2023/02/publish_tauri_to_apples_app_store/) - Details all the steps needed to publish your Mac app to the app store. Includes a sample bash script.
 - [Tauri & ReactJS - Creating Modern Desktop Apps](https://youtube.com/playlist?list=PLmWYh0f8jKSjt9VC5sq2T3mFETasG2p2L) ![youtube] - Creating a modern desktop application with Tauri.
+- [Tauri v2 Auto-Updates Without Maintaining `latest.json`](https://dev.to/eddie_mate/tauri-v2-auto-updates-without-maintaining-latestjson-14de) - Publish signed desktop updates from GitHub Actions without manually maintaining an updater manifest.
 
 ### Templates
 


### PR DESCRIPTION
This is the link to the project: [Tauri v2 Auto-Updates Without Maintaining `latest.json`](https://dev.to/eddie_mate/tauri-v2-auto-updates-without-maintaining-latestjson-14de)

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Uses the required `[Title](link) - Description.` format.
- [x] The entry is in the most appropriate category.
- [x] The description is under 24 words and does not start with “A” or “An”.
- [x] The description contains no links or parentheses.
- [x] The entry has no trailing whitespace.
- [x] This pull request contains one suggestion.
- [x] The commit is signed and verified.

### Additional context

The guide walks through publishing signed Tauri v2 updater artifacts from GitHub Actions and using a dynamic update endpoint instead of maintaining a static `latest.json`.

Validation: `npm exec --yes awesome-lint@0.18.0 -- README.md`
