### PR TITLE
Add Jura Trace to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Defguard](https://github.com/defguard/client) - WireGuard VPN destkop client with Two-factor (2FA) authentication.
 - [Gluhny](https://github.com/angeldollface/gluhny) A graphical interface to validate IMEI numbers.
 - [JumpServer](https://github.com/jumpserver/client/) ![v2] - Open-source PAM client, modern, beautiful, and natively consistent.
+- [Jura Trace](https://juralabs.org/) - Local-first desktop app for image authenticity verification: C2PA provenance signing and AI/deepfake detection, all on-device.
 - [OneKeePass](https://github.com/OneKeePass/desktop) - Secure, modern, cross-platform and KeePass compatible password manager.
 - [Padloc](https://github.com/padloc/padloc) - Modern, open source password manager for individuals and teams.
 - [Secops](https://github.com/kunalsin9h/secops) - Ubuntu Operating System security made easy.


### PR DESCRIPTION
Adds Jura Trace to the Security section under Applications.

**Jura Trace** — open-source (AGPL-3.0-or-later) Tauri v2 desktop app for image authenticity verification: C2PA content-provenance signing/verification, EXIF/metadata forensics, and a trained AI-generated-image/deepfake classifier. Rust core, SvelteKit frontend, Python ML sidecar. Runs entirely on-device.

- Verified the link resolves (200).
- Placed alphabetically between JumpServer and OneKeePass.
- No CONTRIBUTING.md found in the repo; matched the existing entry format/style in this section.

Disclosure: I'm affiliated with Jura Labs, the project's publisher.