### PR TITLE
Add tauri-plugin-widgets to Awesome Tauri

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-plugin-udp](https://github.com/kuyoonjo/tauri-plugin-udp) - UDP socket support.
 - [tauri-plugin-velesdb](https://github.com/cyberlife-coder/VelesDB) - Native vector database plugin. 70µs semantic search, ≥95% recall, hybrid BM25+vector, offline-first, full ecosystem integrations and more.
 - [tauri-plugin-view](https://github.com/ecmel/tauri-plugin-view) - View and share files on mobile.
+- [tauri-plugin-widgets](https://github.com/s00d/tauri-plugin-widgets) ![v2] - Cross-platform home-screen widgets with WidgetKit, AppWidgetManager, Adaptive Cards, and desktop webviews.
 - [tauri-remote-ui](https://github.com/DraviaVemal/tauri-remote-ui) - Make you web app bundle available as web page for test and development.
 - [taurpc](https://github.com/MatsDK/TauRPC) - Typesafe IPC wrapper for Tauri commands and events.
 


### PR DESCRIPTION
This is the link to the project: [tauri-plugin-widgets](https://github.com/s00d/tauri-plugin-widgets)

### Development > Plugins

- Added one entry in alphabetical order:
  - `[tauri-plugin-widgets](https://github.com/s00d/tauri-plugin-widgets) ![v2] - Cross-platform home-screen widgets with WidgetKit, AppWidgetManager, Adaptive Cards, and desktop webviews.`

### Checklist

- [x] I have read the contributing guidelines.
- [x] Uses required `[Title](link) - Description.` format.
- [x] One suggestion in this pull request.
- [x] Description is under 24 words and does not start with `A` or `An`.
- [x] Added alphabetically to the most appropriate category.
- [x] Uses Tauri **v2** badge.
- [x] Works with Tauri 2.x or later.
- [x] Open source, English docs, active, repo older than 30 days.


Made with [Cursor](https://cursor.com)