### PR TITLE
Add Glyph to Office & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Blinko](https://github.com/blinkospace/blinko) ![v2] - Self-hosted personal AI note tool prioritizing privacy.
 - [Ensō](https://enso.sonnet.io) ![closed source] - Write now, edit later. Ensō is a writing tool that helps you enter a state of flow.
 - [Fluster](https://flusterapp.com) ![v2] - The one stop, free and open source note taking application for everything a modern academic or STEM professional needs.
+- [Glyph](https://glyphformac.com/) ![paid] ![v2] - Offline-first Markdown notes app for macOS with local file storage, search, tasks, and optional AI tools.
 - [Handwriting keyboard](https://github.com/BigIskander/Handwriting-keyboard-for-Linux-tesseract) - Handwriting keyboard for Linux X11 desktop environment.
 - [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable, offline-first Markdown editor. Single exe, no install, zero telemetry.
 - [JournalV](https://github.com/ahmedkapro/journalv) - Journaling app for your days and dreams.


### PR DESCRIPTION
Adds Glyph to Office & Writing.

Glyph is an offline-first Markdown notes app for macOS with local file storage, search, tasks, and optional AI tools. The source is available under AGPL-3.0 at [SidhuK/Glyph](https://github.com/SidhuK/Glyph), and official builds are a paid one-time purchase after a 7-day trial, so the entry includes the `![paid]` badge. Glyph uses Tauri 2.

The entry is alphabetically placed in **Office & Writing**, follows the under-24-word description rule, and uses the official website as its link.

The contribution guide requires signed commits. This environment has no GPG executable or configured signing key, so this draft contains an unsigned commit; I can replace it with a signed commit if the maintainer requests one.
