### PR TITLE
Add Zynlex

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Worktree Status](https://github.com/sandercox/worktree-status/) - Get git repo status in your macOS MenuBar or Windows notification area.
 - [Yaak](https://yaak.app) - Organize and execute REST, GraphQL, and gRPC requests.
 - [Yume](https://github.com/aofp/yume) ![v2] - Native desktop GUI for Claude Code with multi-tab sessions, background agents, context compaction, and plugin system.
+- [Zynlex](https://github.com/webtools-dotcom/Zynlex) ![v2] - Developer browser with localhost server detection, per-tab network log, viewport emulation, and header injection rules.
 
 ### Ebook readers
 


### PR DESCRIPTION
Adding Zynlex to Applications > Developer tools.

An open-source browser for web developers built with Tauri 2. The new tab page detects running localhost dev servers, and the sidebar has a per-tab network log, device viewport emulation, header injection rules and an API client. Windows only for now, since tabs, cookies and network capture go through WebView2 COM.

- Repo: https://github.com/webtools-dotcom/Zynlex
- License: Apache-2.0
- Installer: 3.46 MB

Checklist:
- [x] Added alphabetically to the most appropriate category
- [x] Description is under 24 words, does not start with A/An, no links or parenthesis
- [x] No unnecessary words like 'for Tauri'
- [x] `![v2]` badge added
- [x] One suggestion per pull request
- [x] Checked spelling and grammar, no trailing whitespace