### PR TITLE
docs: add GitDesktop to the apps list

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Dropcode](https://github.com/egoist/dropcode) - Simple and lightweight code snippet manager.
 - [Echoo](https://github.com/zsmatrix62/echoo-app) - Offline/Online utilities for developers on MacOS & Windows.
 - [GitButler](https://gitbutler.com) - GitButler is a new Source Code Management system.
+- [GitDesktop](https://github.com/theBGuy/GitDesktop) ![v2] - Keyboard-first Git client for GitHub, GitLab, and Bitbucket with PR, issue, and CI management plus AI-assisted workflows.
 - [Github Security Alerts](https://github.com/stephanebouget/github-security-alerts) ![v2] - Monitors security vulnerabilities across your GitHub repositories in real-time.
 - [GitLight](https://github.com/colinlienard/gitlight) - GitHub & GitLab notifications on your desktop.
 - [JET Pilot](https://www.jet-pilot.app) - Kubernetes desktop client that focuses on less clutter, speed and good looks.


### PR DESCRIPTION
Adds GitDesktop to the curated app listing so the Tauri ecosystem collection covers another actively maintained Git client built on Tauri v2.

- Inserts a `GitDesktop` entry in the applications section of `README.md`, linking to `github.com/theBGuy/GitDesktop` with the `![v2]` badge and a one-line description of its keyboard-first Git workflow across GitHub, GitLab, and Bitbucket.
- Places the entry in alphabetical order between `GitButler` and `Github Security Alerts`, matching the surrounding list's ordering and formatting.