### PR TITLE
Add SimpleMark (Office & Writing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,12 +390,12 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable, offline-first Markdown editor. Single exe, no install, zero telemetry.
 - [JournalV](https://github.com/ahmedkapro/journalv) - Journaling app for your days and dreams.
 - [MarkFlowy](https://github.com/drl990114/MarkFlowy) - Modern markdown editor application with built-in ChatGPT extension.
-- [SimpleMark](https://github.com/StevenRidder/simplemark) ![v2] - Calm local Markdown reader for AI/agent-written documents — always rendered, always your file (Mermaid, Vega, math, file watch).
 - [MD Viewer](https://github.com/kuyoonjo/md-viewer) - Cross-platform markdown viewer.
 - [MDX Notes](https://github.com/maqi1520/mdx-notes/tree/tauri-app) - Versatile WeChat typesetting editor and cross-platform Markdown note-taking software.
 - [Noor](https://noor.to/) ![closed source] - Chat app for high-performance teams. Designed for uninterrupted deep work and rapid collaboration.
 - [Notpad](https://github.com/Muhammed-Rahif/Notpad) - Cross-platform rich text editor with a notepad interface, enhanced with advanced features beyond standard notepad.
 - [Parchment](https://github.com/tywil04/parchment) - Simple local-only cross-platform text editor with basic markdown support.
+- [SimpleMark](https://github.com/StevenRidder/simplemark) ![v2] - Calm local Markdown reader for AI/agent-written documents — always rendered, always your file (Mermaid, Vega, math, file watch).
 - [Semanmeter](https://yibiao.fun/) ![closed source] - OCR and document conversion software.
 - [Ubiquity](https://github.com/opensourcecheemsburgers/ubiquity) - Cross-platform markdown editor; built with Yew, Tailwind, and DaisyUI.
 - [HuLa](https://github.com/HuLaSpark/HuLa) - HuLa is a desktop instant messaging app built on Tauri+Vue3 (not just instant messaging).

--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable, offline-first Markdown editor. Single exe, no install, zero telemetry.
 - [JournalV](https://github.com/ahmedkapro/journalv) - Journaling app for your days and dreams.
 - [MarkFlowy](https://github.com/drl990114/MarkFlowy) - Modern markdown editor application with built-in ChatGPT extension.
+- [SimpleMark](https://github.com/StevenRidder/simplemark) ![v2] - Calm local Markdown reader for AI/agent-written documents — always rendered, always your file (Mermaid, Vega, math, file watch).
 - [MD Viewer](https://github.com/kuyoonjo/md-viewer) - Cross-platform markdown viewer.
 - [MDX Notes](https://github.com/maqi1520/mdx-notes/tree/tauri-app) - Versatile WeChat typesetting editor and cross-platform Markdown note-taking software.
 - [Noor](https://noor.to/) ![closed source] - Chat app for high-performance teams. Designed for uninterrupted deep work and rapid collaboration.


### PR DESCRIPTION
## Summary
Adds [SimpleMark](https://github.com/StevenRidder/simplemark): a Tauri v2 macOS-first local Markdown reader for AI/agent-written documents (rendered document, Mermaid/Vega/math, file watch). Pre-alpha, open for evaluation.

## Checklist
- [x] Entry matches list style
- [x] Link works

Made with [Cursor](https://cursor.com)