### PR TITLE
Add MangoDisk to utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Linka!](https://github.com/linka-app/linka) - AI powered, easy to use, cross-platform bookmark management tool.
 - [Locus](https://github.com/Sushants-Git/locus) - Intelligent activity tracker that helps you understand and improve your focus habits.
 - [MagicMirror](https://github.com/idootop/MagicMirror) - Instant AI Face Swap, Hairstyles & Outfits — One click to a brand new you!
+- [MangoDisk](https://github.com/harry0703/MangoDisk) ![v2] - Open-source disk cleaner for macOS and Windows with visual storage analysis, deep cleaning, exact duplicate detection, and review-before-delete controls.
 - [MBTiles Viewer](https://github.com/Akylas/mbview-rs) - MBTiles Viewer and Inspector.
 - [Metronome](https://github.com/ZaneH/metronome) - Visual metronome for Windows, Linux and macOS.
 - [Mobslide](https://github.com/thewh1teagle/mobslide) - Turn your smartphone into presentation remote controller.


### PR DESCRIPTION
## Summary

- add MangoDisk to Applications → Utilities
- identify it as a Tauri v2 app
- describe its cross-platform disk cleaning and analysis features

## Why

MangoDisk is an open-source Tauri 2 desktop application for macOS and Windows, making it a good fit for the Utilities section.

## Validation

- npm run lint
- confirmed the description is 19 words
- confirmed alphabetical placement