### PR TITLE
Add DueFlow to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [BuildLog](https://github.com/rajatkulkarni95/buildlog) - Menu bar for keeping track of Vercel Deployments.
 - [Clippy](https://github.com/0-don/clippy) - Clipboard manager with sync & encryption.
 - [Dalgona](https://github.com/GHGHGHKO/dalgona) - GIF meme finder app for Windows and macOS.
+- [DueFlow](https://github.com/Ustinian5/DueFlow) ![v2] - Local-first deadline planner with structured intake, reverse schedules, risk checks, calendar export, and a desktop pet.
 - [EcoPaste](https://github.com/ayangweb/EcoPaste/tree/master) - Powerful open-source clipboard manager for macOS, Windows and Linux(x11) platforms.
 - [Fairies](https://fairies.ai) ![closed source] ![paid] - Powerful, general-purpose AI agent for MacOS, Windows, Mobile, and Web.
 - [Floweb](https://floweb.cn/en) ![closed source] ![paid] - Ultra-lightweight floating desktop pendant that transforms web pages into web applications, supporting features such as pinning and transparency, multi-account, auto-refresh.


### PR DESCRIPTION
This is the link to the project: [DueFlow](https://github.com/Ustinian5/DueFlow)

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
- [x] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v1** add the `![v1]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v2** add the `![v2]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.
- [x] I understand that my entry will be removed if it violates the guidelines.
- [ ] I have [signed my commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional).

### Apps

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure.
- [x] If the app is closed source, evidence of it being built with Tauri is included.

### Additional Context

DueFlow is an MIT-licensed, local-first deadline planner for macOS. It turns notices and messages into structured tasks, reverse schedules, risk checks, ICS exports, and desktop-pet reminders. The public source uses Tauri 2, includes an English README and reproducible demo, and has green Python, frontend, smoke, and Rust CI checks.
