### PR TITLE
Add OffPDF to Office & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [MDX Notes](https://github.com/maqi1520/mdx-notes/tree/tauri-app) - Versatile WeChat typesetting editor and cross-platform Markdown note-taking software.
 - [Noor](https://noor.to/) ![closed source] - Chat app for high-performance teams. Designed for uninterrupted deep work and rapid collaboration.
 - [Notpad](https://github.com/Muhammed-Rahif/Notpad) - Cross-platform rich text editor with a notepad interface, enhanced with advanced features beyond standard notepad.
+- [OffPDF](https://github.com/McanKul/offpdf) ![v2] - Offline desktop toolkit for organizing, converting, compressing, securing, and extracting text from PDFs.
 - [Parchment](https://github.com/tywil04/parchment) - Simple local-only cross-platform text editor with basic markdown support.
 - [Semanmeter](https://yibiao.fun/) ![closed source] - OCR and document conversion software.
 - [Ubiquity](https://github.com/opensourcecheemsburgers/ubiquity) - Cross-platform markdown editor; built with Yew, Tailwind, and DaisyUI.


### PR DESCRIPTION
This is the link to the project: [OffPDF](https://github.com/McanKul/offpdf)

Adds OffPDF to **Applications → Office & Writing**.

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the required entry format and Tauri v2 badge.
- [x] Add the entry alphabetically with one suggestion.
- [x] Keep the description under 24 words and check spelling and grammar.
- [x] Sign and verify the commit.

### Apps

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight and secure.

### Verification

- [x] `npm run lint` passes.