### PR TITLE
Add PrismOS-AI to ChatGPT clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Nexo](https://github.com/Nexo-Agent/nexo) - All-in-One Workspace AI
 - [Orion](https://github.com/taecontrol/orion) - Cross-platform app that lets you create multiple AI assistants with specific goals powered with ChatGPT.
 - [Oxide-Lab](https://github.com/FerrisMind/oxide-lab) ![v2] - Local LLM chat application with privacy-focused AI inference using `candle` and Rust backend.
+- [PrismOS-AI](https://github.com/mkbhardwas12/prismos-ai) ![v2] - Ask a local Ollama model about your own files, offline. Local knowledge graph, works with Wi-Fi off.
 - [QuickGPT](https://github.com/dubisdev/quickgpt) - Lightweight AI assistant for Windows.
 - [Yack](https://github.com/rajatkulkarni95/yack) - Spotlight like app for interfacing with GPT APIs.
 


### PR DESCRIPTION
This is the link to the project: [PrismOS-AI](https://github.com/mkbhardwas12/prismos-ai)

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] If the project is closed source add the `![closed source]` badge after the `(link)` but before the `-`.
- [x] If the project/article is non-free or paywalled add the `![paid]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v1** add the `![v1]` badge after the `(link)` but before the `-`.
- [x] If the project/article uses Tauri **v2** add the `![v2]` badge after the `(link)` but before the `-`.
- [x] Add entries alphabetically to the most appropriate category.
- [x] No unnecessary words like `for Tauri`, `a Tauri plugin` and `Super-Fast`.
- [x] Description does not start with `A` or `An`.
- [x] Description is under 24 words.
- [x] Description has no links or parenthesis.
- [x] Use `backticks` when mentioning package names.
- [x] Double-check spelling and grammar.
- [x] No trailing whitespace is added to the end of any file.
- [x] One suggestion per pull request.

Added under **ChatGPT clients**, alphabetically between Oxide-Lab and QuickGPT:

```markdown
- [PrismOS-AI](https://github.com/mkbhardwas12/prismos-ai) ![v2] - Ask a local Ollama model about your own files, offline. Local knowledge graph, works with Wi-Fi off.
```

Tauri 2 desktop app, MIT licensed, offline-first (CSP allow-list is `self` + localhost Ollama only).