### PR TITLE
docs: add DeepSeek Harness Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Yume](https://github.com/aofp/yume) ![v2] - Native desktop GUI for Claude Code with multi-tab sessions, background agents, context compaction, and plugin system.
 
 ### Ebook readers
+- [DeepSeek Harness Desktop](https://github.com/fendouai/deepseek-harness-desktop) - The plugin-native AI agent workspace, packaged as a real desktop app.
 
 - [Alexandria](https://github.com/btpf/Alexandria) - Minimalistic cross-platform eBook reader.
 - [Jane Reader](https://janereader.com) ![closed source] - Modern and distraction-free epub reader.


### PR DESCRIPTION
Add [deepseek-harness-desktop](https://github.com/fendouai/deepseek-harness-desktop) to the Developer tools section.

A Tauri 2 desktop app that packages DeepSeek Harness (plugin-native AI agent workspace) with the complete Web UI, a supervised local sidecar, and a bundled Node.js 24 runtime. Local by design, cross-platform (macOS/Linux/Windows), MIT licensed.