### PR TITLE
Add MetaClean to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [Defguard](https://github.com/defguard/client) - WireGuard VPN destkop client with Two-factor (2FA) authentication.
 - [Gluhny](https://github.com/angeldollface/gluhny) A graphical interface to validate IMEI numbers.
 - [JumpServer](https://github.com/jumpserver/client/) ![v2] - Open-source PAM client, modern, beautiful, and natively consistent.
+- [MetaClean](https://github.com/Moresyl/metaclean) ![v2] - Locally inspects and removes sensitive metadata from images, PDFs, Office documents, and text files.
 - [OneKeePass](https://github.com/OneKeePass/desktop) - Secure, modern, cross-platform and KeePass compatible password manager.
 - [Padloc](https://github.com/padloc/padloc) - Modern, open source password manager for individuals and teams.
 - [Secops](https://github.com/kunalsin9h/secops) - Ubuntu Operating System security made easy.


### PR DESCRIPTION
This is the link to the project: [MetaClean](https://github.com/Moresyl/metaclean)

- [x] **I have read the [contributing guidelines](https://github.com/tauri-apps/awesome-tauri/blob/dev/.github/contributing.md).**
- [x] Use the following format: `[Title](link) - Description.`
- [x] The project uses Tauri **v2**, so the `![v2]` badge is included.
- [x] The entry is alphabetical in the Security category.
- [x] The description is under 24 words, starts without “A” or “An”, and contains no links or parentheses.
- [x] Spelling, grammar, and trailing whitespace were checked.
- [x] This pull request contains one suggestion.

### Apps

- [x] The app is original and not too simple.
- [x] The README is in English.
- [x] The app makes a reasonable effort to be fast, lightweight, and secure.
- [x] The app is open source; its Tauri 2 configuration is visible in the repository.

### Additional Context

MetaClean runs locally and removes sensitive metadata from images, PDFs, Office documents, and text files. It provides cross-platform desktop releases for Windows, macOS, and Linux.