### PR TITLE
add oxide-dock template

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [angular-tauri](https://github.com/maximegris/angular-tauri) - Angular with Typescript, SASS, and Hot Reload.
 - [create-tauri-react](https://github.com/MrLightful/create-tauri-react) - Well-architected template for Vite, React, and Tailwind CSS.
 - [nuxtor](https://github.com/NicolaSpadari/nuxtor) - Nuxt 4 + Tauri 2 + TailwindCSS v4, a starter template for building desktop apps.
+- [oxide-dock](https://github.com/fridzema/oxide-dock) ![v2] - Vue 3 with Vite, Tailwind CSS, typed Rust bridge, Vitest, Playwright, coverage-gated Rust tests, and automated cross-platform releases via `release-please`.
 - [rust-full-stack-with-authentication-template](https://github.com/sollambert/rust-full-stack-with-auth-template) - Yew, Tailwind CSS, Tauri, Axum, Sqlx - Starter template for full stack applications with built-in authentication.
 - [tauri-angular-template](https://github.com/charlesxsh/tauri-angular-boilerplate) - Angular template
 - [tauri-astro-template](https://github.com/HuakunShen/tauri-astro-template) - Astro template


### PR DESCRIPTION
Adds [oxide-dock](https://github.com/fridzema/oxide-dock), a Tauri v2 + Vue 3 starter template.

Checklist:
- Works with Tauri 2.x
- Repo created 2026-02-13, well over 30 days old
- Documentation in English, with quick start and a full command reference
- One suggestion in this PR
- Entry added alphabetically to Templates
- Commit is signed

How it differs from the existing Vue entries: `tauri-vue-template` covers Vue + TypeScript + Vitest + GitHub Actions, and `tauri-vue-template-2` is a JavaScript template. oxide-dock adds Playwright e2e, a coverage-gated Rust test suite, `cargo-audit`, structured Rust error types with a typed IPC layer, Lefthook and commitlint hooks, and fully automated cross-platform releases via release-please that publish .deb, .AppImage, .dmg, .msi and .exe artifacts.