### PR TITLE
Add Earkeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ A curated collection of the best stuff from the Tauri ecosystem and community.
 - [tauri-update-server](https://git.kaki87.net/KaKi87/tauri-update-server) ![v1] - Automatically interface the Tauri updater with git repository releases.
 - [vite-plugin-tauri](https://github.com/amrbashir/vite-plugin-tauri) ![v2] - Integrate Tauri in a Vite project to build cross-platform apps.
 
+## Applications
+
+### Audio & Video
+
+- [Earkeep](https://earkeep.com) - Ambient meeting transcriber — always-on mic and system audio capture, local whisper.cpp transcription, and retroactive meeting definition via timeline.
+
 [officially maintained]: https://img.shields.io/badge/official-FFC131?&logo=tauri&logoColor=black
 [closed source]: https://img.shields.io/badge/closed%20source-FFC131?&logoColor=black
 [paid]: https://img.shields.io/badge/paid-FFC131?&logoColor=black


### PR DESCRIPTION
Add [Earkeep](https://earkeep.com) — ambient meeting transcriber (Tauri 2 app) with always-on mic and system audio capture, local whisper.cpp transcription, and retroactive meeting definition via timeline. Added to new Applications → Audio & Video section.